### PR TITLE
Use different encoding code pages depending on the user's locale

### DIFF
--- a/src/UniGetUI.Core.Data/CoreData.cs
+++ b/src/UniGetUI.Core.Data/CoreData.cs
@@ -7,7 +7,7 @@ namespace UniGetUI.Core.Data
 {
     public static class CoreData
     {
-        private static int? __code_page = null;
+        private static int? __code_page;
         public static int CODE_PAGE { get => __code_page ??= GetCodePage(); }
         
         private static int GetCodePage()

--- a/src/UniGetUI.Core.Data/CoreData.cs
+++ b/src/UniGetUI.Core.Data/CoreData.cs
@@ -1,13 +1,40 @@
 ﻿using System.Diagnostics;
 using System.Net;
+using System.Runtime.InteropServices;
 using UniGetUI.Core.Logging;
 
 namespace UniGetUI.Core.Data
 {
     public static class CoreData
     {
-        public const int CODE_PAGE = 0;
+        private static int? __code_page = null;
+        public static int CODE_PAGE { get => __code_page ??= GetCodePage(); }
         
+        private static int GetCodePage()
+        {
+            try
+            {
+                Process p = new Process()
+                {
+                    StartInfo = new ProcessStartInfo()
+                    {
+                        FileName = "chcp.com",
+                        RedirectStandardOutput = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                    }
+                };
+                p.Start();
+                string contents = p.StandardOutput.ReadToEnd();
+                return int.Parse(contents.Split(':')[^1].Trim());
+            } 
+            catch (Exception e)
+            {
+                Logger.Error(e);
+                return 0;
+            }
+        }
+
         public const string VersionName =  "3.1.0"; // Do not modify this line, use file scripts/apply_versions.py
         public const double VersionNumber =  3.1; // Do not modify this line, use file scripts/apply_versions.py
 

--- a/src/UniGetUI.Core.Data/CoreData.cs
+++ b/src/UniGetUI.Core.Data/CoreData.cs
@@ -6,6 +6,8 @@ namespace UniGetUI.Core.Data
 {
     public static class CoreData
     {
+        public const int CODE_PAGE = 0;
+        
         public const string VersionName =  "3.1.0"; // Do not modify this line, use file scripts/apply_versions.py
         public const double VersionNumber =  3.1; // Do not modify this line, use file scripts/apply_versions.py
 

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -90,8 +90,8 @@ namespace UniGetUI.Core.Tools
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     CreateNoWindow = true,
-                    StandardOutputEncoding = CodePagesEncodingProvider.Instance.GetEncoding(437),
-                    StandardErrorEncoding = CodePagesEncodingProvider.Instance.GetEncoding(437),
+                    StandardOutputEncoding = CodePagesEncodingProvider.Instance.GetEncoding(CoreData.CODE_PAGE),
+                    StandardErrorEncoding = CodePagesEncodingProvider.Instance.GetEncoding(CoreData.CODE_PAGE),
                 }
             };
             process.Start();

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -90,7 +90,8 @@ namespace UniGetUI.Core.Tools
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     CreateNoWindow = true,
-                    StandardOutputEncoding = System.Text.Encoding.UTF8
+                    StandardOutputEncoding = CodePagesEncodingProvider.Instance.GetEncoding(437),
+                    StandardErrorEncoding = CodePagesEncodingProvider.Instance.GetEncoding(437),
                 }
             };
             process.Start();

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.Tools;
 using UniGetUI.PackageEngine.Classes.Manager.Classes;
@@ -24,9 +25,9 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
         private LocalWingetSource GOGSource { get; set; }
         private LocalWingetSource MicrosoftStoreSource { get; set; }
 
-        private readonly string PowerShellPath;
-        private readonly string PowerShellPromptArgs;
-        private readonly string PowerShellInlineArgs;
+        public readonly string PowerShellPath;
+        public readonly string PowerShellPromptArgs;
+        public readonly string PowerShellInlineArgs;
 
         public WinGet() : base()
         {
@@ -114,7 +115,7 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
         protected override async Task<Package[]> GetAvailableUpdates_UnSafe()
         {
             List<Package> Packages = [];
-
+            
             Process p = new()
             {
                 StartInfo = new ProcessStartInfo()
@@ -126,9 +127,9 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
                     CreateNoWindow = true,
-                    StandardOutputEncoding = CodePagesEncodingProvider.Instance.GetEncoding(437),
+                    StandardOutputEncoding = CodePagesEncodingProvider.Instance.GetEncoding(CoreData.CODE_PAGE),
                     StandardInputEncoding = new UTF8Encoding(false),
-                    StandardErrorEncoding = CodePagesEncodingProvider.Instance.GetEncoding(437),
+                    StandardErrorEncoding = CodePagesEncodingProvider.Instance.GetEncoding(CoreData.CODE_PAGE),
                 }
             };
 
@@ -207,9 +208,9 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
                     CreateNoWindow = true,
-                    StandardOutputEncoding = CodePagesEncodingProvider.Instance.GetEncoding(437),
+                    StandardOutputEncoding = CodePagesEncodingProvider.Instance.GetEncoding(CoreData.CODE_PAGE),
                     StandardInputEncoding = new UTF8Encoding(false),
-                    StandardErrorEncoding = CodePagesEncodingProvider.Instance.GetEncoding(437),
+                    StandardErrorEncoding = CodePagesEncodingProvider.Instance.GetEncoding(CoreData.CODE_PAGE),
                 }
             };
 

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -119,16 +119,16 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
             {
                 StartInfo = new ProcessStartInfo()
                 {
-                    FileName = PowerShellPath,
-                    Arguments = PowerShellPromptArgs,
+                    FileName = "cmd.exe",
+                    Arguments = "/C " + PowerShellPath + " " + PowerShellPromptArgs,
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
                     CreateNoWindow = true,
-                    StandardOutputEncoding = System.Text.Encoding.UTF8,
+                    StandardOutputEncoding = CodePagesEncodingProvider.Instance.GetEncoding(437),
                     StandardInputEncoding = new UTF8Encoding(false),
-                    StandardErrorEncoding = System.Text.Encoding.UTF8,
+                    StandardErrorEncoding = CodePagesEncodingProvider.Instance.GetEncoding(437),
                 }
             };
 
@@ -196,21 +196,20 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
         protected override async Task<Package[]> GetInstalledPackages_UnSafe()
         {
             List<Package> Packages = [];
-
             Process p = new()
             {
                 StartInfo = new ProcessStartInfo()
-                {
-                    FileName = PowerShellPath,
-                    Arguments = PowerShellPromptArgs,
+                {                    
+                    FileName = "cmd.exe",
+                    Arguments = "/C " + PowerShellPath + " " + PowerShellPromptArgs,
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
                     CreateNoWindow = true,
-                    StandardOutputEncoding = System.Text.Encoding.UTF8,
-                    StandardErrorEncoding = System.Text.Encoding.UTF8,
+                    StandardOutputEncoding = CodePagesEncodingProvider.Instance.GetEncoding(437),
                     StandardInputEncoding = new UTF8Encoding(false),
+                    StandardErrorEncoding = CodePagesEncodingProvider.Instance.GetEncoding(437),
                 }
             };
 

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Management.Deployment;
 using System.Diagnostics;
+using System.Text;
 using System.Text.RegularExpressions;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
@@ -425,13 +426,16 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
             {
                 StartInfo = new ProcessStartInfo()
                 {
-                    FileName = "powershell.exe",
+                    FileName = "cmd.exe",
+                    Arguments = "/C " + ManagerInstance.PowerShellPath + " " + ManagerInstance.PowerShellPromptArgs,
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
                     CreateNoWindow = true,
-                    StandardOutputEncoding = System.Text.Encoding.UTF8
+                    StandardOutputEncoding = CodePagesEncodingProvider.Instance.GetEncoding(CoreData.CODE_PAGE),
+                    StandardInputEncoding = new UTF8Encoding(false),
+                    StandardErrorEncoding = CodePagesEncodingProvider.Instance.GetEncoding(CoreData.CODE_PAGE),
                 }
             };
 
@@ -440,7 +444,8 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
             ManagerClasses.Classes.ProcessTaskLogger logger = ManagerInstance.TaskLogger.CreateNew(LoggableTaskType.FindPackages, p);
 
             string command = """
-                Set-ExecutionPolicy Bypass -Scope Process -Force
+                Write-Output (Get-Module -Name Microsoft.WinGet.Client).Version
+                Import-Module Microsoft.WinGet.Client
                 function Print-WinGetPackage {
                     param (
                         [Parameter(Mandatory,ValueFromPipelineByPropertyName)] [string] $Name,

--- a/src/UniGetUI/EntryPoint.cs
+++ b/src/UniGetUI/EntryPoint.cs
@@ -47,17 +47,19 @@ namespace UniGetUI
         {
             try
             {
-                string textart = @"
-   __  __      _ ______     __  __  ______
-  / / / /___  (_) ____/__  / /_/ / / /  _/
- / / / / __ \/ / / __/ _ \/ __/ / / // /  
-/ /_/ / / / / / /_/ /  __/ /_/ /_/ // /   
-\____/_/ /_/_/\____/\___/\__/\____/___/   
-    Welcome to UniGetUI Version " + CoreData.VersionName;
+                string textart = $"""
+                     __  __      _ ______     __  __  ______
+                    / / / /___  (_) ____/__  / /_/ / / /  _/
+                   / / / / __ \/ / / __/ _ \/ __/ / / // /  
+                  / /_/ / / / / / /_/ /  __/ /_/ /_/ // /   
+                  \____/_/ /_/_/\____/\___/\__/\____/___/   
+                      Welcome to UniGetUI Version {CoreData.VersionName}
+                  """;
 
                 Logger.ImportantInfo(textart);
                 Logger.ImportantInfo("  ");
-                Logger.ImportantInfo("Version Code:  " + CoreData.VersionNumber.ToString());
+                Logger.ImportantInfo($"Version Code:  {CoreData.VersionNumber}");
+                Logger.ImportantInfo($"Encoding Code Page set to {CoreData.CODE_PAGE}");
 
                 // WinRT single-instance fancy stuff
                 WinRT.ComWrappersSupport.InitializeComWrappers();


### PR DESCRIPTION
The corresponding encoding will be used for loading WinGet packages and for loading paths with the CoreTools.Which method. Systems that did not support/did had disabled the UTF-8 beta support were experiencing character corruption both in paths and in Packages with non-standard characters

fix #2242 
fix #2239