### PR TITLE
Use new titlebar control (AppSdk 1.6+)

### DIFF
--- a/src/UniGetUI/Interface/MainWindow.xaml
+++ b/src/UniGetUI/Interface/MainWindow.xaml
@@ -25,12 +25,29 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
-                <RowDefinition Height="36"/>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
-            <Border Grid.Row="0" Grid.Column="0" x:Name="__app_titlebar" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+            <TitleBar
+                Name="titlebar"
+                Title="UniGetUI"
+                IsPaneToggleButtonVisible="False"
+                IsBackButtonVisible="False"
+                Subtitle="formerly WingetUI">
+                <TitleBar.IconSource>
+                    <ImageIconSource ImageSource="ms-appx:///Assets/Images/icon.png" />
+                </TitleBar.IconSource>
+                <TextBox 
+                    Name="GenericSearchBox" 
+                    Width="400" 
+                    PlaceholderText="Search anything" 
+                    Margin="4,0,4,0" Height="30"
+                    >
+                </TextBox>
+            </TitleBar>
+            <!--Border Grid.Row="0" Grid.Column="0" x:Name="__app_titlebar" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Stretch" Margin="12,8,12,8" Spacing="10">
                     <Image VerticalAlignment="Stretch" HorizontalAlignment="Left" Width="16" Height="16" >
                         <Image.Source>
@@ -39,7 +56,7 @@
                     </Image>
                     <widgets:TranslatedTextBlock x:Name="AppTitle" Text="WingetUI" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" FontSize="12"/>
                 </StackPanel>
-            </Border>
+            </Border-->
             <InfoBar Name="UpdatesBanner" x:FieldModifier="public" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" IsOpen="False" Visibility="{x:Bind UpdatesBanner.IsOpen, Mode=OneWay}" Margin="0,0,0,4" CornerRadius="0" BorderThickness="0,1,0,1"/>
             <InfoBar Name="ErrorBanner" x:FieldModifier="public" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" IsOpen="False" Visibility="{x:Bind ErrorBanner.IsOpen, Mode=OneWay}" Margin="0,0,0,4" Severity="Error" CornerRadius="0" BorderThickness="0,1,0,1"/>
         </Grid>

--- a/src/UniGetUI/Interface/MainWindow.xaml.cs
+++ b/src/UniGetUI/Interface/MainWindow.xaml.cs
@@ -77,23 +77,41 @@ namespace UniGetUI.Interface
 
         public List<NavButton> NavButtonList = [];
 #pragma warning disable CS8618
+
         public MainWindow()
         {
             InitializeComponent();
             LoadTrayMenu();
             ExtendsContentIntoTitleBar = true;
-            SetTitleBar(__content_root);
+            //SetTitleBar(__content_root);
             ContentRoot = __content_root;
             ApplyTheme();
 
             SizeChanged += (s, e) => { SaveGeometry(); };
+            
+            titlebar.Loaded += (sender, args) =>
+            {
+                VisualStateManager.GoToState(titlebar, "SubtitleTextVisible", false);
+                VisualStateManager.GoToState(titlebar, "HeaderVisible", false);
+                VisualStateManager.GoToState(titlebar, "ContentVisible", false);
+                VisualStateManager.GoToState(titlebar, "FooterVisible", false);
 
-            AppWindow.SetIcon(Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Images", "icon.ico"));
+                // Run layout so we re-calculate the drag regions.
+                titlebar.InvalidateMeasure();
+            };
+
+            //titlebar.IconSource = new BitmapIconSource() { UriSource = new Uri("ms-appx:///Assets/Images/icon.png") };
+            titlebar.Title = "UniGetUI";
+            titlebar.Subtitle = CoreTools.Translate("formerly known as WingetUI");
+            //titlebar.Content = new TextBox();
+            //AppWindow.SetIcon(Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Images", "icon.ico"));
             if (CoreTools.IsAdministrator())
             {
                 Title = "UniGetUI " + CoreTools.Translate("[RAN AS ADMINISTRATOR]");
-                AppTitle.Text = Title;
+                titlebar.Title = Title;
             }
+            ExtendsContentIntoTitleBar = true;
+            SetTitleBar(titlebar);
 
             LoadingSthDalog = new ContentDialog
             {
@@ -101,6 +119,7 @@ namespace UniGetUI.Interface
                 Title = CoreTools.Translate("Please wait"),
                 Content = new ProgressBar { IsIndeterminate = true, Width = 300 }
             };
+
         }
 #pragma warning restore CS8618
         public void HandleNotificationActivation(ToastArguments args, ValueSet input)
@@ -352,7 +371,7 @@ namespace UniGetUI.Interface
 
         public void SwitchToInterface()
         {
-            SetTitleBar(__app_titlebar);
+            //SetTitleBar(__app_titlebar);
             ContentRoot = __content_root;
 
             NavigationPage = new MainView();

--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -35,7 +35,9 @@
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <AssemblyName>WingetUI</AssemblyName>
 	<Nullable>enable</Nullable>
-	
+    <WindowsSdkPackageVersion>10.0.22621.35-preview</WindowsSdkPackageVersion>
+
+
   </PropertyGroup>
   <ItemGroup>
     <Content Include="icon.ico" />
@@ -77,7 +79,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Notifications" Version="7.1.2" />
     <PackageReference Include="H.NotifyIcon.WinUI" Version="2.0.131" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240607001" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240701003-experimental2" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
Take advantage of the newly introduced TitleBar control on the App Sdk.

fix #2403

![image](https://github.com/user-attachments/assets/77ab5525-5586-43f0-9102-09b2a342bd9e)
