### PR TITLE
Fix CA1823: Avoid unused private fields

### DIFF
--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/ManagerLogger.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/ManagerLogger.cs
@@ -44,7 +44,6 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Classes
         protected IEnumerable<string>? CachedVerboseMessage;
 
         private const int RETURNCODE_UNSET = -200;
-        private const int RETURNCODE_SUCCESS = 0;
         protected int ReturnCode = -200;
 
         public TaskLogger()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. Thank you for your understanding.
-----
<!-- optionally, explain here about the committed code -->
Forgot to fix one warning: [CA1823](https://learn.microsoft.com/pl-pl/dotnet/fundamentals/code-analysis/quality-rules/ca1823)
-----
Relates to https://github.com/marticliment/UniGetUI/pull/2527
