### PR TITLE
Fixed pre-release workflow

### DIFF
--- a/.github/workflows/winget-prerelease.yml
+++ b/.github/workflows/winget-prerelease.yml
@@ -3,7 +3,7 @@ name: Publish prereleases to WinGet
 on:
   release:
     types: [published]  # Trigger on published release (includes prereleases)
-  workflow_dispatch:  # Allow manual trigger via GitHub Actions UI
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/winget-prerelease.yml
+++ b/.github/workflows/winget-prerelease.yml
@@ -1,13 +1,17 @@
 name: Publish prereleases to WinGet
+
 on:
   release:
-    types: [prereleased]
-  workflow_dispatch:
+    types: [published]  # Trigger on published release (includes prereleases)
+
 jobs:
   publish:
+    if: github.event.release.prerelease == true  # Ensure this only runs for prereleases
     runs-on: ubuntu-latest
+
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - name: Publish to WinGet
+        uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: MartiCliment.UniGetUI.Pre-Release
           version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/winget-prerelease.yml
+++ b/.github/workflows/winget-prerelease.yml
@@ -3,6 +3,7 @@ name: Publish prereleases to WinGet
 on:
   release:
     types: [published]  # Trigger on published release (includes prereleases)
+  workflow_dispatch:  # Allow manual trigger via GitHub Actions UI
 
 jobs:
   publish:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. Thank you for your understanding.
-----

I found that the GitHub action did not run with your latest pre-release. After some more digging I found the the prereleased type is a bit misleading. Following this PR change it should actually work now.

![image](https://github.com/user-attachments/assets/761c3b37-41a4-4cd1-a1ae-eb3a5ca3719c)

-----

