### PR TITLE
Add Helper class to cache and load WinGet Native Packages

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using ABI.System.Collections.Generic;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
@@ -230,6 +231,14 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
 
             return status;
         }
+
+        // For future usage
+        private void ReRegisterCOMServer()
+        {
+            WinGetHelper.Instance = new NativeWinGetHelper();
+            NativePackageHandler.Clear();
+        }
+
 
         public override void RefreshPackageIndexes()
         {

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativePackageHandler.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativePackageHandler.cs
@@ -109,6 +109,14 @@ public static class NativePackageHandler
         return installerInfo;
     }
 
+    public static void Clear()
+    {
+        __nativePackages.Clear();;
+        __nativeDetails.Clear();;
+        __nativeInstallers_Install.Clear();;
+        __nativeInstallers_Uninstall.Clear();
+    }
+
     private static PackageInstallerInfo? _getInstallationOptionsOnDict(IPackage package, ref ConcurrentDictionary<long, PackageInstallerInfo> source, bool installed)
     {
         if (source.TryGetValue(package.GetHash(), out PackageInstallerInfo? installerInfo))

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativePackageHandler.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativePackageHandler.cs
@@ -1,0 +1,129 @@
+using System.Collections.Concurrent;
+using Microsoft.Management.Deployment;
+using UniGetUI.Core.Logging;
+using UniGetUI.PackageEngine.Enums;
+using UniGetUI.PackageEngine.Interfaces;
+
+namespace UniGetUI.PackageEngine.Managers.WingetManager;
+
+public static class NativePackageHandler
+{
+    private static ConcurrentDictionary<long, CatalogPackage> __nativePackages = new();
+    private static ConcurrentDictionary<long, CatalogPackageMetadata> __nativeDetails = new();
+    private static ConcurrentDictionary<long, PackageInstallerInfo> __nativeInstallers_Install = new();
+    private static ConcurrentDictionary<long, PackageInstallerInfo> __nativeInstallers_Uninstall = new();
+
+    /// <summary>
+    /// Get (cache or load) the native package for the given package, if any;
+    /// </summary>
+    /// <returns></returns>
+    public static CatalogPackage? GetPackage(IPackage package)
+    {
+        if (NativeWinGetHelper.ExternalFactory is null || NativeWinGetHelper.ExternalManager is null)
+            return null;
+
+        __nativePackages.TryGetValue(package.GetHash(), out CatalogPackage? catalogPackage);
+        if (catalogPackage is not null)
+            return catalogPackage;
+
+        PackageCatalogReference Catalog = NativeWinGetHelper.ExternalManager.GetPackageCatalogByName(package.Source.Name);
+        if (Catalog is null)
+        {
+            Logger.Error("Failed to get catalog " + package.Source.Name + ". Is the package local?");
+            return null;
+        }
+
+        // Connect to catalog
+        Catalog.AcceptSourceAgreements = true;
+        ConnectResult ConnectResult = Catalog.Connect();
+        if (ConnectResult.Status != ConnectResultStatus.Ok)
+        {
+            Logger.Error("Failed to connect to catalog " + package.Source.Name);
+            return null;
+        }
+
+        // Match only the exact same Id
+        FindPackagesOptions packageMatchFilter = NativeWinGetHelper.ExternalFactory.CreateFindPackagesOptions();
+        PackageMatchFilter filters = NativeWinGetHelper.ExternalFactory.CreatePackageMatchFilter();
+        filters.Field = PackageMatchField.Id;
+        filters.Value = package.Id;
+        filters.Option = PackageFieldMatchOption.Equals;
+        packageMatchFilter.Filters.Add(filters);
+        packageMatchFilter.ResultLimit = 1;
+        var SearchResult = Task.Run(() => ConnectResult.PackageCatalog.FindPackages(packageMatchFilter));
+
+        if (SearchResult?.Result?.Matches is null ||
+            SearchResult.Result.Matches.Count == 0)
+        {
+            Logger.Error("Failed to find package " + package.Id + " in catalog " + package.Source.Name);
+            return null;
+        }
+
+        // Get the Native Package
+        catalogPackage = SearchResult.Result.Matches.First().CatalogPackage;
+        AddPackage(package, catalogPackage);
+
+        return catalogPackage;
+    }
+
+    /// <summary>
+    /// Adds an external CatalogPackage to the internal database
+    /// </summary>
+    public static void AddPackage(IPackage package, CatalogPackage catalogPackage)
+    {
+        __nativePackages[package.GetHash()] = catalogPackage;
+    }
+
+    /// <summary>
+    /// Get (cached or load) the native package details for the given package, if any;
+    /// </summary>
+    public static CatalogPackageMetadata? GetDetails(IPackage package)
+    {
+        if (__nativeDetails.TryGetValue(package.GetHash(), out CatalogPackageMetadata? metadata))
+            return metadata;
+
+        CatalogPackage? catalogPackage = GetPackage(package);
+        metadata = catalogPackage?.DefaultInstallVersion?.GetCatalogPackageMetadata();
+        metadata ??= catalogPackage?.InstalledVersion?.GetCatalogPackageMetadata();
+
+        if (metadata is not null)
+            __nativeDetails[package.GetHash()] = metadata;
+
+        return metadata;
+    }
+
+    /// <summary>
+    /// Get (cached or load) the native installer for the given package, if any. The operation type determines wether
+    /// </summary>
+    public static PackageInstallerInfo? GetInstallationOptions(IPackage package, OperationType operation)
+    {
+        if (NativeWinGetHelper.ExternalFactory is null)
+            return null;
+
+        PackageInstallerInfo? installerInfo = null;
+        if (operation is OperationType.Uninstall)
+            installerInfo = _getInstallationOptionsOnDict(package, ref __nativeInstallers_Uninstall, true);
+        else
+            installerInfo = _getInstallationOptionsOnDict(package, ref __nativeInstallers_Uninstall, false);
+
+        return installerInfo;
+    }
+
+    private static PackageInstallerInfo? _getInstallationOptionsOnDict(IPackage package, ref ConcurrentDictionary<long, PackageInstallerInfo> source, bool installed)
+    {
+        if (source.TryGetValue(package.GetHash(), out PackageInstallerInfo? installerInfo))
+            return installerInfo;
+
+        PackageVersionInfo? catalogPackage;
+        if (installed) catalogPackage = GetPackage(package)?.InstalledVersion;
+        else catalogPackage = GetPackage(package)?.DefaultInstallVersion;
+
+        InstallOptions? options = NativeWinGetHelper.ExternalFactory?.CreateInstallOptions();
+        installerInfo = catalogPackage?.GetApplicableInstaller(options);
+
+        if (installerInfo is not null)
+            source[package.GetHash()] = installerInfo;
+
+        return installerInfo;
+    }
+}

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
@@ -947,6 +947,8 @@ namespace UniGetUI.Interface
                 var icon = await Task.Run(wrapper.Package.GetIconUrlIfAny);
                 if(icon is not null) wrapper.PackageIcon = icon;
             }
+
+            FilterPackages();
         }
     }
 }

--- a/src/UniGetUI/UniGetUI.csproj
+++ b/src/UniGetUI/UniGetUI.csproj
@@ -6,7 +6,7 @@
     <RuntimeIdentifier>win-$(Platform)</RuntimeIdentifier>
     <Platforms>ARM64;x64</Platforms>
     <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
-   <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <Authors>Martí Climent and the contributors</Authors>
     <PublisherName>Martí Climent</PublisherName>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
### NOTE: This is an icon-focused improvement.

Instead of loading the native packages each time they are needed in order to get the details, the icon or the installer options, cache said native package and prevent unneeded calls to the package catalog, drastically reducing CPU usage and icon loading time.

PROS:
 - Way faster loading times for details, icons and native installationOptions
 - Less CPU impact
 - More accurate installationOptions (operation type dependent)

CONS:
 - More susceptible to COM Server reset issues
 - Potential (but almost insignificant) RAM usage increase