### PR TITLE
Create a new TaskRecycler class to cache reusable function calls

### DIFF
--- a/src/UniGetUI.Core.Classes.Tests/TaskRecyclerTests.cs
+++ b/src/UniGetUI.Core.Classes.Tests/TaskRecyclerTests.cs
@@ -1,0 +1,78 @@
+namespace UniGetUI.Core.Classes.Tests;
+
+public class TaskRecyclerTests
+{
+    private int MySlowMethod1()
+    {
+        Thread.Sleep(1000);
+        return (new Random()).Next();
+    }
+
+    class TestClass
+    {
+        public TestClass() {}
+        public string SlowMethod2()
+        {
+            Thread.Sleep(1000);
+            return (new Random()).Next().ToString();
+        }
+    }
+
+    [Fact]
+    public void TestTaskRecycler_Static_Int()
+    {
+        // The same static method should be cached, and therefore the return value should be the same
+        var task1 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod1);
+        var task2 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod1);
+        int result1 = task1.GetAwaiter().GetResult();
+        int result2 = task2.GetAwaiter().GetResult();
+        Assert.Equal(result1, result2);
+
+        // The same static method should be cached, and therefore the return value should be the same, but different from previous runs
+        var task3 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod1);
+        var task4 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod1);
+        int result4 = task4.GetAwaiter().GetResult();
+        int result3 = task3.GetAwaiter().GetResult();
+        Assert.Equal(result3, result4);
+
+        // Ensure the last call was not permanently cached
+        Assert.NotEqual(result1, result3);
+    }
+
+    [Fact]
+    public void TestTaskRecycler_Class_String()
+    {
+        var class1 = new TestClass();
+        var class2 = new TestClass();
+
+        // The SAME method from the SAME instance should be cached,
+        // and therefore the return value should be the same
+        var task1 = TaskRecycler<string>.RunOrAttachAsync(class1.SlowMethod2);
+        var task2 = TaskRecycler<string>.RunOrAttachAsync(class1.SlowMethod2);
+        string result1 = task1.GetAwaiter().GetResult();
+        string result2 = task2.GetAwaiter().GetResult();
+        Assert.Equal(result1, result2);
+
+
+        var class1_copy = class1;
+
+        // The SAME method from the SAME instance, even when called
+        // from different variable names should be cached, and therefore the return value should be the same
+        var task5 = TaskRecycler<string>.RunOrAttachAsync(class1_copy.SlowMethod2);
+        var task6 = TaskRecycler<string>.RunOrAttachAsync(class1.SlowMethod2);
+        string result5 = task5.GetAwaiter().GetResult();
+        string result6 = task6.GetAwaiter().GetResult();
+        Assert.Equal(result5, result6);
+
+        // The SAME method from two DIFFERENT instances should NOT be
+        // cached, so the results should differ
+        var task3 = TaskRecycler<string>.RunOrAttachAsync(class1.SlowMethod2);
+        var task4 = TaskRecycler<string>.RunOrAttachAsync(class2.SlowMethod2);
+        string result4 = task4.GetAwaiter().GetResult();
+        string result3 = task3.GetAwaiter().GetResult();
+        Assert.NotEqual(result3, result4);
+
+        // Ensure the last call was not permanently cached
+        Assert.NotEqual(result1, result3);
+    }
+}

--- a/src/UniGetUI.Core.Classes.Tests/TaskRecyclerTests.cs
+++ b/src/UniGetUI.Core.Classes.Tests/TaskRecyclerTests.cs
@@ -11,7 +11,14 @@ public class TaskRecyclerTests
     class TestClass
     {
         public TestClass() {}
+
         public string SlowMethod2()
+        {
+            Thread.Sleep(1000);
+            return (new Random()).Next().ToString();
+        }
+
+        public string SlowMethod3()
         {
             Thread.Sleep(1000);
             return (new Random()).Next().ToString();
@@ -74,5 +81,14 @@ public class TaskRecyclerTests
 
         // Ensure the last call was not permanently cached
         Assert.NotEqual(result1, result3);
+
+
+        // The SAME method from two DIFFERENT instances should NOT be
+        // cached, so the results should differ
+        var task7 = TaskRecycler<string>.RunOrAttachAsync(class1.SlowMethod3);
+        var task8 = TaskRecycler<string>.RunOrAttachAsync(class2.SlowMethod2);
+        string result7 = task7.GetAwaiter().GetResult();
+        string result8 = task8.GetAwaiter().GetResult();
+        Assert.NotEqual(result7, result8);
     }
 }

--- a/src/UniGetUI.Core.Classes.Tests/TaskRecyclerTests.cs
+++ b/src/UniGetUI.Core.Classes.Tests/TaskRecyclerTests.cs
@@ -25,6 +25,12 @@ public class TaskRecyclerTests
         }
     }
 
+    private int MySlowMethod4(int argument)
+    {
+        Thread.Sleep(1000);
+        return (new Random()).Next() + (argument - argument);
+    }
+
     [Fact]
     public void TestTaskRecycler_Static_Int()
     {
@@ -44,6 +50,29 @@ public class TaskRecyclerTests
 
         // Ensure the last call was not permanently cached
         Assert.NotEqual(result1, result3);
+    }
+
+    [Fact]
+    public void TestTaskRecycler_StaticWithArgument_Int()
+    {
+        // The same static method should be cached, and therefore the return value should be the same
+        var task1 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod4, 2);
+        var task2 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod4, 2);
+        var task3 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod4, 3);
+        int result1 = task1.GetAwaiter().GetResult();
+        int result2 = task2.GetAwaiter().GetResult();
+        int result3 = task3.GetAwaiter().GetResult();
+        Assert.Equal(result1, result2);
+        Assert.NotEqual(result1, result3);
+
+        // The same static method should be cached, and therefore the return value should be the same, but different from previous runs
+        var task4 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod4, 2);
+        var task5 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod4, 3);
+        int result4 = task4.GetAwaiter().GetResult();
+        int result5 = task5.GetAwaiter().GetResult();
+        Assert.NotEqual(result4, result5);
+        Assert.NotEqual(result1, result4);
+        Assert.NotEqual(result3, result5);
     }
 
     [Fact]

--- a/src/UniGetUI.Core.Classes.Tests/TaskRecyclerTests.cs
+++ b/src/UniGetUI.Core.Classes.Tests/TaskRecyclerTests.cs
@@ -53,6 +53,48 @@ public class TaskRecyclerTests
     }
 
     [Fact]
+    public void TestTaskRecycler_Static_Int_WithCache()
+    {
+        // The same static method should be cached, and therefore the return value should be the same
+        var task1 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
+        var task2 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
+        int result1 = task1.GetAwaiter().GetResult();
+        int result2 = task2.GetAwaiter().GetResult();
+        Assert.Equal(result1, result2);
+
+        // The same static method should be cached, and therefore the return value should be the same,
+        // and equal to previous runs due to 3 seconds cache
+        var task3 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
+        var task4 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
+        int result4 = task4.GetAwaiter().GetResult();
+        int result3 = task3.GetAwaiter().GetResult();
+        Assert.Equal(result3, result4);
+        Assert.Equal(result1, result3);
+
+        // Wait for caches to clear
+        Thread.Sleep(3000);
+
+        // The same static method should be cached, but cached runs should have been removed. This results should differ from previous ones
+        var task5 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
+        var task6 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
+        int result5 = task6.GetAwaiter().GetResult();
+        int result6 = task5.GetAwaiter().GetResult();
+        Assert.Equal(result5, result6);
+        Assert.NotEqual(result4, result5);
+
+        // Clear cache
+        TaskRecycler<int>.RemoveFromCache(MySlowMethod1);
+
+        // The same static method should be cached, but cached runs should have been cleared manually. This results should differ from previous ones
+        var task7 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
+        var task8 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
+        int result7 = task7.GetAwaiter().GetResult();
+        int result8 = task8.GetAwaiter().GetResult();
+        Assert.Equal(result7, result8);
+        Assert.NotEqual(result6, result7);
+    }
+
+    [Fact]
     public void TestTaskRecycler_StaticWithArgument_Int()
     {
         // The same static method should be cached, and therefore the return value should be the same

--- a/src/UniGetUI.Core.Classes/SortableObservableCollection.cs
+++ b/src/UniGetUI.Core.Classes/SortableObservableCollection.cs
@@ -3,6 +3,9 @@ using System.Collections.Specialized;
 
 namespace UniGetUI.Core.Classes
 {
+    /*
+     * An observable sorted collection that keeps IIndexableListItem indexes up to date
+     */
     public class SortableObservableCollection<T> : ObservableCollection<T> where T : IIndexableListItem
     {
         public Func<T, object>? SortingSelector { get; set; }

--- a/src/UniGetUI.Core.Classes/TaskRecycler.cs
+++ b/src/UniGetUI.Core.Classes/TaskRecycler.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+
+namespace UniGetUI.Core.Classes;
+
+/*
+ * This static class can help reduce the CPU
+ * impact of calling a CPU-intensive method
+ * that is expected to return the same result when
+ * called twice concurrently.
+ *
+ * This can apply to getting the locally installed
+ * packages, for example.
+ */
+public static class TaskRecycler<T>
+{
+    private static ConcurrentDictionary<int, Task<T>> _tasks = new();
+
+    public static async Task<T> RunOrAttachAsync(Func<T> method)
+    {
+        int hash = method.GetHashCode();
+        if (_tasks.TryGetValue(hash, out Task<T>? currentTask))
+        {
+            return await currentTask;
+        }
+
+        Task<T> task = Task.Run(method);
+        _tasks[hash] = task;
+        /* BEGIN WAIT */
+        T result = await task;
+        /* END WAIT */
+        _tasks.Remove(hash, out _);
+        return result;
+    }
+}

--- a/src/UniGetUI.Core.Classes/TaskRecycler.cs
+++ b/src/UniGetUI.Core.Classes/TaskRecycler.cs
@@ -13,6 +13,11 @@ namespace UniGetUI.Core.Classes;
  *
  * This can apply to getting the locally installed
  * packages, for example.
+ *
+ *
+ * WARNING: When using TaskRecycler with methods that return instances of classes
+ * the return instance WILL BE THE SAME when the call attaches to an existing call.
+ * Take this into account when handling received objects.
  */
 public static class TaskRecycler<ReturnT>
 {

--- a/src/UniGetUI.Core.Classes/UniGetUI.Core.Classes.csproj
+++ b/src/UniGetUI.Core.Classes/UniGetUI.Core.Classes.csproj
@@ -25,4 +25,8 @@
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs" Link="SharedAssemblyInfo.cs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UniGetUI.Core.Logger\UniGetUI.Core.Logging.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/UniGetUI.Core.IconStore/IconCacheEngine.cs
+++ b/src/UniGetUI.Core.IconStore/IconCacheEngine.cs
@@ -83,7 +83,9 @@ namespace UniGetUI.Core.IconEngine
                 return null;
 
             var icon = _icon.Value;
-            string extension = icon.Url.AbsolutePath[icon.Url.AbsolutePath.LastIndexOf('.')..][1..];
+            string extension;
+            if (icon.Url.AbsolutePath.LastIndexOf('.') >= 0) extension = icon.Url.AbsolutePath[icon.Url.AbsolutePath.LastIndexOf('.')..][1..];
+            else extension = "png";
 
             if (extension.Length > 6)
             {

--- a/src/UniGetUI.Core.IconStore/IconCacheEngine.cs
+++ b/src/UniGetUI.Core.IconStore/IconCacheEngine.cs
@@ -134,7 +134,7 @@ namespace UniGetUI.Core.IconEngine
             using HttpClient client = new(CoreData.GenericHttpClientParameters);
             client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
             HttpResponseMessage response = await client.GetAsync(icon.Url);
-            if (response.IsSuccessStatusCode)
+            if (!response.IsSuccessStatusCode)
             {
                 Logger.Warn($"Icon download attempt at {icon.Url} failed with code {response.StatusCode}");
                 return null;

--- a/src/UniGetUI.Core.IconStore/IconCacheEngine.cs
+++ b/src/UniGetUI.Core.IconStore/IconCacheEngine.cs
@@ -80,12 +80,9 @@ namespace UniGetUI.Core.IconEngine
         public static async Task<string?> GetCacheOrDownloadIcon(CacheableIcon? _icon, string ManagerName, string PackageId)
         {
             if (_icon is null)
-            {
                 return null;
-            }
 
-            var icon = (CacheableIcon)_icon;
-
+            var icon = _icon.Value;
             string extension = icon.Url.AbsolutePath[icon.Url.AbsolutePath.LastIndexOf('.')..][1..];
 
             if (extension.Length > 6)
@@ -121,17 +118,13 @@ namespace UniGetUI.Core.IconEngine
             // If a valid cache was found, return that cache
             if (isLocalCacheValid)
             {
-                Logger.Debug($"Icon for package {PackageId} is VALID and won't be downloaded again (verification method is {icon.ValidationMethod})");
+                Logger.Debug($"Cached icon for id={PackageId} is valid and won't be downloaded again ({icon.ValidationMethod})");
                 return cachedIconFile;
-                // Exit the function
             }
-            else if (localCacheExists)
+
+            if (localCacheExists)
             {
-                Logger.ImportantInfo($"Icon for Package={PackageId} Manager={ManagerName} Uri={icon.Url} is NOT VALID (verification method is {icon.ValidationMethod})");
-            }
-            else
-            {
-                Logger.Debug($"Icon for package {PackageId} on manager {ManagerName} was not found on cache, downloading it...");
+                Logger.ImportantInfo($"Cached ocon for id={PackageId} is INVALID ({icon.ValidationMethod})");
             }
 
             // If the cache is determined to NOT be valid, delete cache
@@ -141,7 +134,12 @@ namespace UniGetUI.Core.IconEngine
             using HttpClient client = new(CoreData.GenericHttpClientParameters);
             client.DefaultRequestHeaders.UserAgent.ParseAdd(CoreData.UserAgentString);
             HttpResponseMessage response = await client.GetAsync(icon.Url);
-            response.EnsureSuccessStatusCode();
+            if (response.IsSuccessStatusCode)
+            {
+                Logger.Warn($"Icon download attempt at {icon.Url} failed with code {response.StatusCode}");
+                return null;
+            }
+
             using (Stream stream = await response.Content.ReadAsStreamAsync())
                 using (FileStream fileStream = File.Create(cachedIconFile))
                 {
@@ -153,8 +151,6 @@ namespace UniGetUI.Core.IconEngine
 
             if (icon.ValidationMethod is IconValidationMethod.UriSource)
                 await File.WriteAllTextAsync(iconUriFile, icon.Url.ToString());
-
-            Logger.Info($"Icon for package {PackageId} stored on {cachedIconFile}");
 
             // Ensure the new icon has been properly downloaded
             bool isNewCacheValid = icon.ValidationMethod switch
@@ -168,7 +164,6 @@ namespace UniGetUI.Core.IconEngine
 
             if (isNewCacheValid)
             {
-                Logger.Info($"NEWLY DOWNLOADED Icon for Package={PackageId} Manager={ManagerName} Uri={icon.Url} is VALID (verification method is {icon.ValidationMethod})");
                 return cachedIconFile;
             }
             else

--- a/src/UniGetUI.PackageEngine.Enums/Enums.cs
+++ b/src/UniGetUI.PackageEngine.Enums/Enums.cs
@@ -86,5 +86,9 @@ namespace UniGetUI.PackageEngine.Enums
         /// Loads the available versions for a specific package
         /// </summary>
         LoadPackageVersions,
+        /// <summary>
+        /// Other, specific task
+        /// </summary>
+        OtherTask
     }
 }

--- a/src/UniGetUI.PackageEngine.Managers.Cargo/Cargo.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Cargo/Cargo.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
+using UniGetUI.Core.Classes;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.Tools;
 using UniGetUI.PackageEngine.Classes.Manager;
@@ -143,9 +144,26 @@ public partial class Cargo : PackageManager
     private IEnumerable<Package> GetPackages(LoggableTaskType taskType)
     {
         List<Package> Packages = [];
+        foreach(var match in TaskRecycler<List<Match>>.RunOrAttachOrCache(GetInstalledCommandOutput, 15))
+        {
+            var id = match.Groups[1].Value.Trim();
+            var name = CoreTools.FormatAsName(id);
+            var oldVersion = match.Groups[2].Value;
+            var newVersion = match.Groups[3].Value;
+            if(taskType is LoggableTaskType.ListUpdates && oldVersion != newVersion)
+                Packages.Add(new Package(name, id, oldVersion, newVersion, DefaultSource, this));
+            else if(taskType is LoggableTaskType.ListInstalledPackages)
+                Packages.Add(new Package(name, id, oldVersion, DefaultSource, this));
+        }
+        return Packages;
+    }
 
+    private List<Match> GetInstalledCommandOutput()
+    {
+        List<Match> output = new();
         Process p = GetProcess(Status.ExecutablePath, "install-update --list");
-        IProcessTaskLogger logger = TaskLogger.CreateNew(taskType, p);
+        IProcessTaskLogger logger = TaskLogger.CreateNew(LoggableTaskType.OtherTask, p);
+        logger.AddToStdOut("Other task: Call the install-update command");
         p.Start();
 
         string? line;
@@ -155,20 +173,13 @@ public partial class Cargo : PackageManager
             var match = UpdateLineRegex().Match(line);
             if (match.Success)
             {
-                var id = match.Groups[1].Value.Trim();
-                var name = CoreTools.FormatAsName(id);
-                var oldVersion = match.Groups[2].Value;
-                var newVersion = match.Groups[3].Value;
-                if(taskType is LoggableTaskType.ListUpdates && oldVersion != newVersion)
-                    Packages.Add(new Package(name, id, oldVersion, newVersion, DefaultSource, this));
-                else if(taskType is LoggableTaskType.ListInstalledPackages)
-                    Packages.Add(new Package(name, id, oldVersion, DefaultSource, this));
+                output.Add(match);
             }
         }
         logger.AddToStdErr(p.StandardError.ReadToEnd());
         p.WaitForExit();
         logger.Close(p.ExitCode);
-        return Packages;
+        return output;
     }
 
     private Process GetProcess(string fileName, string extraArguments)

--- a/src/UniGetUI.PackageEngine.Managers.Chocolatey/Providers/ChocolateySourceProvider.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Chocolatey/Providers/ChocolateySourceProvider.cs
@@ -22,12 +22,12 @@ namespace UniGetUI.PackageEngine.Managers.ChocolateyManager
             return ["source", "remove", "--name", source.Name, "-y"];
         }
 
-        public override OperationVeredict GetAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        protected override OperationVeredict _getAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
         {
             return ReturnCode == 0 ? OperationVeredict.Succeeded : OperationVeredict.Failed;
         }
 
-        public override OperationVeredict GetRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        protected override OperationVeredict _getRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
         {
             return ReturnCode == 0 ? OperationVeredict.Succeeded : OperationVeredict.Failed;
         }

--- a/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGetDetailsProvider.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Generic.NuGet/BaseNuGetDetailsProvider.cs
@@ -132,11 +132,11 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
 
             if (!possibleIconUrl.Success)
             {
-                Logger.Warn($"No Icon URL could be parsed on the manifest Url={NuGetManifestLoader.GetManifestUrl(package).ToString()}");
+                // Logger.Warn($"No Icon URL could be parsed on the manifest Url={NuGetManifestLoader.GetManifestUrl(package).ToString()}");
                 return null;
             }
 
-            Logger.Debug($"A native icon with Url={possibleIconUrl.Groups[1].Value} was found");
+            // Logger.Debug($"A native icon with Url={possibleIconUrl.Groups[1].Value} was found");
             return new CacheableIcon(new Uri(possibleIconUrl.Groups[1].Value), package.Version);
         }
 

--- a/src/UniGetUI.PackageEngine.Managers.PowerShell/Providers/PowerShellSourceProvider.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell/Providers/PowerShellSourceProvider.cs
@@ -29,12 +29,12 @@ namespace UniGetUI.PackageEngine.Managers.PowerShellManager
             return ["Unregister-PSRepository", "-Name", source.Name];
         }
 
-        public override OperationVeredict GetAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        protected override OperationVeredict _getAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
         {
             return ReturnCode == 0 ? OperationVeredict.Succeeded : OperationVeredict.Failed;
         }
 
-        public override OperationVeredict GetRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        protected override OperationVeredict _getRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
         {
             return ReturnCode == 0 ? OperationVeredict.Succeeded : OperationVeredict.Failed;
         }

--- a/src/UniGetUI.PackageEngine.Managers.PowerShell7/Providers/PowerShell7SourceProvider.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell7/Providers/PowerShell7SourceProvider.cs
@@ -29,12 +29,12 @@ namespace UniGetUI.PackageEngine.Managers.PowerShell7Manager
             return ["Unregister-PSRepository", "-Name", source.Name];
         }
 
-        public override OperationVeredict GetAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        protected override OperationVeredict _getAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
         {
             return ReturnCode == 0 ? OperationVeredict.Succeeded : OperationVeredict.Failed;
         }
 
-        public override OperationVeredict GetRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        protected override OperationVeredict _getRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
         {
             return ReturnCode == 0 ? OperationVeredict.Succeeded : OperationVeredict.Failed;
         }

--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Providers/ScoopSourceProvider.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Providers/ScoopSourceProvider.cs
@@ -14,7 +14,7 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
     {
         public ScoopSourceProvider(Scoop manager) : base(manager) { }
 
-        public override OperationVeredict GetAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        protected override OperationVeredict _getAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
         {
             return ReturnCode == 0 ? OperationVeredict.Succeeded : OperationVeredict.Failed;
         }
@@ -24,7 +24,7 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
             return ["bucket", "add", source.Name, source.Url.ToString()];
         }
 
-        public override OperationVeredict GetRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        protected override OperationVeredict _getRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
         {
             return ReturnCode == 0 ? OperationVeredict.Succeeded : OperationVeredict.Failed;
         }

--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using UniGetUI.Core.Classes;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
@@ -163,7 +164,12 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
                         continue;
                     }
 
-                    Packages.Add(new Package(Core.Tools.CoreTools.FormatAsName(elements[0]), elements[0], elements[1].Replace("(", "").Replace(")", ""), source, this));
+                    Packages.Add(new Package(
+                        CoreTools.FormatAsName(elements[0]),
+                        elements[0],
+                        elements[1].Replace("(", "").Replace(")", ""),
+                        source,
+                        this));
                 }
             }
             logger.AddToStdErr(p.StandardError.ReadToEnd());
@@ -235,7 +241,14 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
                     if (InstalledPackages.TryGetValue(elements[0] + "." + elements[1], out IPackage? InstalledPackage))
                     {
                         OverridenInstallationOptions options = new(InstalledPackage.OverridenOptions.Scope);
-                        Packages.Add(new Package(CoreTools.FormatAsName(elements[0]), elements[0], elements[1], elements[2], InstalledPackage.Source, this, options));
+                        Packages.Add(new Package(
+                            CoreTools.FormatAsName(elements[0]),
+                            elements[0],
+                            elements[1],
+                            elements[2],
+                            InstalledPackage.Source,
+                            this,
+                            options));
                     }
                     else
                     {
@@ -250,6 +263,8 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
         }
 
         protected override IEnumerable<Package> GetInstalledPackages_UnSafe()
+            => TaskRecycler<IEnumerable<Package>>.RunOrAttach(_getInstalledPackages_UnSafe);
+        private IEnumerable<Package> _getInstalledPackages_UnSafe()
         {
             List<Package> Packages = [];
 
@@ -303,7 +318,13 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
                         line.Contains("Global install") ? PackageScope.Global : PackageScope.User
                     );
 
-                    Packages.Add(new Package(CoreTools.FormatAsName(elements[0]), elements[0], elements[1], GetSourceOrDefault(elements[2]), this, options));
+                    Packages.Add(new Package(
+                        CoreTools.FormatAsName(elements[0]),
+                        elements[0],
+                        elements[1],
+                        GetSourceOrDefault(elements[2]),
+                        this,
+                        options));
                 }
             }
             logger.AddToStdErr(p.StandardError.ReadToEnd());

--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs
@@ -263,7 +263,7 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
         }
 
         protected override IEnumerable<Package> GetInstalledPackages_UnSafe()
-            => TaskRecycler<IEnumerable<Package>>.RunOrAttach(_getInstalledPackages_UnSafe);
+            => TaskRecycler<IEnumerable<Package>>.RunOrAttachOrCache(_getInstalledPackages_UnSafe, 15);
         private IEnumerable<Package> _getInstalledPackages_UnSafe()
         {
             List<Package> Packages = [];

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Providers/WinGetPackageDetailsProvider.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Providers/WinGetPackageDetailsProvider.cs
@@ -227,12 +227,12 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
             {
                 if (icon is not null && icon.Url is not null)
                 {
-                    Logger.Debug($"Found WinGet native icon for {package.Id} with URL={icon.Url}");
+                    // Logger.Debug($"Found WinGet native icon for {package.Id} with URL={icon.Url}");
                     return new CacheableIcon(new Uri(icon.Url), icon.Sha256);
                 }
             }
 
-            Logger.Debug($"Native WinGet icon for Package={package.Id} on catalog={package.Source.Name} was not found :(");
+            // Logger.Debug($"Native WinGet icon for Package={package.Id} on catalog={package.Source.Name} was not found :(");
             return null;
         }
     }

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Providers/WinGetPackageDetailsProvider.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Providers/WinGetPackageDetailsProvider.cs
@@ -14,17 +14,17 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
     internal sealed class WinGetPackageDetailsProvider : BasePackageDetailsProvider<UniGetUIManagers.PackageManager>
     {
         private static readonly Dictionary<string, string> __msstore_package_manifests = [];
-        
+
         public WinGetPackageDetailsProvider(WinGet manager) : base(manager) { }
 
         protected override IEnumerable<string> GetInstallableVersions_UnSafe(IPackage package)
         {
-            return WinGetHelper.Instance.GetInstallableVersions_Unsafe((WinGet)Manager, package);
+            return WinGetHelper.Instance.GetInstallableVersions_Unsafe(package);
         }
 
         protected override void GetDetails_UnSafe(IPackageDetails details)
         {
-            WinGetHelper.Instance.GetPackageDetails_UnSafe((WinGet)Manager, details);
+            WinGetHelper.Instance.GetPackageDetails_UnSafe(details);
         }
 
         protected override CacheableIcon? GetIcon_UnSafe(IPackage package)

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Providers/WinGetSourceProvider.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Providers/WinGetSourceProvider.cs
@@ -25,12 +25,12 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
             return ["source", "remove", "--name", source.Name, "--disable-interactivity"];
         }
 
-        public override OperationVeredict GetAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        protected override OperationVeredict _getAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
         {
             return ReturnCode == 0 ? OperationVeredict.Succeeded : OperationVeredict.Failed;
         }
 
-        public override OperationVeredict GetRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        protected override OperationVeredict _getRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
         {
             return ReturnCode == 0 ? OperationVeredict.Succeeded : OperationVeredict.Failed;
         }

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/Providers/WinGetSourceProvider.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/Providers/WinGetSourceProvider.cs
@@ -37,12 +37,7 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
 
         protected override IEnumerable<IManagerSource> GetSources_UnSafe()
         {
-            if (Manager is WinGet manager)
-            {
-                return WinGetHelper.Instance.GetSources_UnSafe(manager);
-            }
-
-            throw new InvalidOperationException("WinGetSourceProvider.GetSources_UnSafe: Manager is supposed to be WinGet");
+            return WinGetHelper.Instance.GetSources_UnSafe();
         }
     }
 }

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGet.cs
@@ -88,19 +88,19 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
 
         protected override IEnumerable<Package> FindPackages_UnSafe(string query)
         {
-            return WinGetHelper.Instance.FindPackages_UnSafe(this, query);
+            return WinGetHelper.Instance.FindPackages_UnSafe(query);
         }
 
         protected override IEnumerable<Package> GetAvailableUpdates_UnSafe()
         {
-            return WinGetHelper.Instance.GetAvailableUpdates_UnSafe(this);
+            return WinGetHelper.Instance.GetAvailableUpdates_UnSafe();
         }
 
         protected override IEnumerable<Package> GetInstalledPackages_UnSafe()
         {
             try
             {
-                var packages = WinGetHelper.Instance.GetInstalledPackages_UnSafe(this);
+                var packages = WinGetHelper.Instance.GetInstalledPackages_UnSafe();
                 NO_PACKAGES_HAVE_BEEN_LOADED = !packages.Any();
                 return packages;
             }
@@ -211,12 +211,12 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
             {
                 if (FORCE_BUNDLED)
                 {
-                    WinGetHelper.Instance = new BundledWinGetHelper();
+                    WinGetHelper.Instance = new BundledWinGetHelper(this);
                     status.Version += "\nUsing bundled WinGet helper (CLI parsing)";
                 }
                 else
                 {
-                    WinGetHelper.Instance = new NativeWinGetHelper();
+                    WinGetHelper.Instance = new NativeWinGetHelper(this);
                     status.Version += "\nUsing Native WinGet helper (COM Api)";
                 }
             }
@@ -225,7 +225,7 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
                 Logger.Warn($"Cannot instantiate {(FORCE_BUNDLED? "Bundled" : "Native")} WinGet Helper due to error: {ex.Message}");
                 Logger.Warn(ex);
                 Logger.Warn("WinGet will resort to using BundledWinGetHelper()");
-                WinGetHelper.Instance = new BundledWinGetHelper();
+                WinGetHelper.Instance = new BundledWinGetHelper(this);
                 status.Version += "\nUsing bundled WinGet helper (CLI parsing, caused by exception)";
             }
 
@@ -235,7 +235,7 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
         // For future usage
         private void ReRegisterCOMServer()
         {
-            WinGetHelper.Instance = new NativeWinGetHelper();
+            WinGetHelper.Instance = new NativeWinGetHelper(this);
             NativePackageHandler.Clear();
         }
 

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/BundledWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/BundledWinGetHelper.cs
@@ -15,7 +15,14 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager;
 
 internal sealed class BundledWinGetHelper : IWinGetManagerHelper
 {
-    public IEnumerable<Package> GetAvailableUpdates_UnSafe(WinGet Manager)
+    private WinGet Manager;
+
+    public BundledWinGetHelper(WinGet manager)
+    {
+        Manager = manager;
+    }
+
+    public IEnumerable<Package> GetAvailableUpdates_UnSafe()
     {
         List<Package> Packages = [];
         Process p = new()
@@ -111,7 +118,7 @@ internal sealed class BundledWinGetHelper : IWinGetManagerHelper
         return Packages;
     }
 
-    public IEnumerable<Package> GetInstalledPackages_UnSafe(WinGet Manager)
+    public IEnumerable<Package> GetInstalledPackages_UnSafe()
     {
         List<Package> Packages = [];
         Process p = new()
@@ -202,7 +209,7 @@ internal sealed class BundledWinGetHelper : IWinGetManagerHelper
         return Packages;
     }
 
-    public IEnumerable<Package> FindPackages_UnSafe(WinGet Manager, string query)
+    public IEnumerable<Package> FindPackages_UnSafe(string query)
     {
         List<Package> Packages = [];
         Process p = new()
@@ -276,7 +283,7 @@ internal sealed class BundledWinGetHelper : IWinGetManagerHelper
 
 
 
-    public void GetPackageDetails_UnSafe(WinGet Manager, IPackageDetails details)
+    public void GetPackageDetails_UnSafe(IPackageDetails details)
     {
         if (details.Package.Source.Name == "winget")
         {
@@ -508,7 +515,7 @@ internal sealed class BundledWinGetHelper : IWinGetManagerHelper
         return;
     }
 
-    public IEnumerable<string> GetInstallableVersions_Unsafe(WinGet Manager, IPackage package)
+    public IEnumerable<string> GetInstallableVersions_Unsafe(IPackage package)
     {
         Process p = new()
         {
@@ -555,7 +562,7 @@ internal sealed class BundledWinGetHelper : IWinGetManagerHelper
         return versions;
     }
 
-    public IEnumerable<IManagerSource> GetSources_UnSafe(WinGet Manager)
+    public IEnumerable<IManagerSource> GetSources_UnSafe()
     {
         List<IManagerSource> sources = [];
 

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/IWinGetManagerHelpers.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/IWinGetManagerHelpers.cs
@@ -10,11 +10,11 @@ namespace UniGetUI.PackageEngine.Managers.WingetManager
 
     internal interface IWinGetManagerHelper
     {
-        public IEnumerable<Package> GetAvailableUpdates_UnSafe(WinGet Manager);
-        public IEnumerable<Package> GetInstalledPackages_UnSafe(WinGet Manager);
-        public IEnumerable<Package> FindPackages_UnSafe(WinGet Manager, string query);
-        public IEnumerable<IManagerSource> GetSources_UnSafe(WinGet Manager);
-        public IEnumerable<string> GetInstallableVersions_Unsafe(WinGet Manager, IPackage package);
-        public void GetPackageDetails_UnSafe(WinGet Manager, IPackageDetails details);
+        public IEnumerable<Package> GetAvailableUpdates_UnSafe();
+        public IEnumerable<Package> GetInstalledPackages_UnSafe();
+        public IEnumerable<Package> FindPackages_UnSafe(string query);
+        public IEnumerable<IManagerSource> GetSources_UnSafe();
+        public IEnumerable<string> GetInstallableVersions_Unsafe(IPackage package);
+        public void GetPackageDetails_UnSafe(IPackageDetails details);
     }
 }

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativePackageHandler.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativePackageHandler.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Microsoft.Management.Deployment;
+using UniGetUI.Core.Classes;
 using UniGetUI.Core.Logging;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
@@ -25,6 +26,94 @@ public static class NativePackageHandler
         __nativePackages.TryGetValue(package.GetHash(), out CatalogPackage? catalogPackage);
         if (catalogPackage is not null)
             return catalogPackage;
+
+        // Rarely a package will not be available in cache (native WinGet helper should always call AddPackage)
+        // so it makes no sense to add TaskRecycler.RunOrAttach() here. (Only imported packages may arrive at this point)
+        catalogPackage = _findPackageOnCatalog(package);
+        if(catalogPackage is not null) AddPackage(package, catalogPackage);
+
+        return catalogPackage;
+    }
+
+    /// <summary>
+    /// Adds an external CatalogPackage to the internal database
+    /// </summary>
+    public static void AddPackage(IPackage package, CatalogPackage catalogPackage)
+    {
+        __nativePackages[package.GetHash()] = catalogPackage;
+    }
+
+    /// <summary>
+    /// Get (cached or load) the native package details for the given package, if any;
+    /// </summary>
+    public static CatalogPackageMetadata? GetDetails(IPackage package)
+        => TaskRecycler<CatalogPackageMetadata?>.RunOrAttach(_getDetails, package);
+
+    private static CatalogPackageMetadata? _getDetails(IPackage package)
+    {
+        if (__nativeDetails.TryGetValue(package.GetHash(), out CatalogPackageMetadata? metadata))
+            return metadata;
+
+        CatalogPackage? catalogPackage = GetPackage(package);
+        metadata = catalogPackage?.DefaultInstallVersion?.GetCatalogPackageMetadata();
+        metadata ??= catalogPackage?.InstalledVersion?.GetCatalogPackageMetadata();
+
+        if (metadata is not null)
+            __nativeDetails[package.GetHash()] = metadata;
+
+        return metadata;
+    }
+
+    /// <summary>
+    /// Get (cached or load) the native installer for the given package, if any. The operation type determines wether
+    /// </summary>
+    public static PackageInstallerInfo? GetInstallationOptions(IPackage package, OperationType operation)
+        =>  TaskRecycler<PackageInstallerInfo?>.RunOrAttach(_getInstallationOptions, package, operation);
+
+    private static PackageInstallerInfo? _getInstallationOptions(IPackage package, OperationType operation)
+    {
+        if (NativeWinGetHelper.ExternalFactory is null)
+            return null;
+
+        PackageInstallerInfo? installerInfo;
+        if (operation is OperationType.Uninstall)
+            installerInfo = _getInstallationOptionsOnDict(package, ref __nativeInstallers_Uninstall, true);
+        else
+            installerInfo = _getInstallationOptionsOnDict(package, ref __nativeInstallers_Uninstall, false);
+
+        return installerInfo;
+    }
+
+    public static void Clear()
+    {
+        __nativePackages.Clear();;
+        __nativeDetails.Clear();;
+        __nativeInstallers_Install.Clear();;
+        __nativeInstallers_Uninstall.Clear();
+    }
+
+    private static PackageInstallerInfo? _getInstallationOptionsOnDict(IPackage package, ref ConcurrentDictionary<long, PackageInstallerInfo> source, bool installed)
+    {
+        if (source.TryGetValue(package.GetHash(), out PackageInstallerInfo? installerInfo))
+            return installerInfo;
+
+        PackageVersionInfo? catalogPackage;
+        if (installed) catalogPackage = GetPackage(package)?.InstalledVersion;
+        else catalogPackage = GetPackage(package)?.DefaultInstallVersion;
+
+        InstallOptions? options = NativeWinGetHelper.ExternalFactory?.CreateInstallOptions();
+        installerInfo = catalogPackage?.GetApplicableInstaller(options);
+
+        if (installerInfo is not null)
+            source[package.GetHash()] = installerInfo;
+
+        return installerInfo;
+    }
+
+    private static CatalogPackage? _findPackageOnCatalog(IPackage package)
+    {
+        if (NativeWinGetHelper.ExternalWinGetManager is null || NativeWinGetHelper.ExternalFactory is null)
+            return null;
 
         PackageCatalogReference Catalog = NativeWinGetHelper.ExternalWinGetManager.GetPackageCatalogByName(package.Source.Name);
         if (Catalog is null)
@@ -59,79 +148,7 @@ public static class NativePackageHandler
             return null;
         }
 
-        // Get the Native Package
-        catalogPackage = SearchResult.Result.Matches.First().CatalogPackage;
-        AddPackage(package, catalogPackage);
-
-        return catalogPackage;
-    }
-
-    /// <summary>
-    /// Adds an external CatalogPackage to the internal database
-    /// </summary>
-    public static void AddPackage(IPackage package, CatalogPackage catalogPackage)
-    {
-        __nativePackages[package.GetHash()] = catalogPackage;
-    }
-
-    /// <summary>
-    /// Get (cached or load) the native package details for the given package, if any;
-    /// </summary>
-    public static CatalogPackageMetadata? GetDetails(IPackage package)
-    {
-        if (__nativeDetails.TryGetValue(package.GetHash(), out CatalogPackageMetadata? metadata))
-            return metadata;
-
-        CatalogPackage? catalogPackage = GetPackage(package);
-        metadata = catalogPackage?.DefaultInstallVersion?.GetCatalogPackageMetadata();
-        metadata ??= catalogPackage?.InstalledVersion?.GetCatalogPackageMetadata();
-
-        if (metadata is not null)
-            __nativeDetails[package.GetHash()] = metadata;
-
-        return metadata;
-    }
-
-    /// <summary>
-    /// Get (cached or load) the native installer for the given package, if any. The operation type determines wether
-    /// </summary>
-    public static PackageInstallerInfo? GetInstallationOptions(IPackage package, OperationType operation)
-    {
-        if (NativeWinGetHelper.ExternalFactory is null)
-            return null;
-
-        PackageInstallerInfo? installerInfo = null;
-        if (operation is OperationType.Uninstall)
-            installerInfo = _getInstallationOptionsOnDict(package, ref __nativeInstallers_Uninstall, true);
-        else
-            installerInfo = _getInstallationOptionsOnDict(package, ref __nativeInstallers_Uninstall, false);
-
-        return installerInfo;
-    }
-
-    public static void Clear()
-    {
-        __nativePackages.Clear();;
-        __nativeDetails.Clear();;
-        __nativeInstallers_Install.Clear();;
-        __nativeInstallers_Uninstall.Clear();
-    }
-
-    private static PackageInstallerInfo? _getInstallationOptionsOnDict(IPackage package, ref ConcurrentDictionary<long, PackageInstallerInfo> source, bool installed)
-    {
-        if (source.TryGetValue(package.GetHash(), out PackageInstallerInfo? installerInfo))
-            return installerInfo;
-
-        PackageVersionInfo? catalogPackage;
-        if (installed) catalogPackage = GetPackage(package)?.InstalledVersion;
-        else catalogPackage = GetPackage(package)?.DefaultInstallVersion;
-
-        InstallOptions? options = NativeWinGetHelper.ExternalFactory?.CreateInstallOptions();
-        installerInfo = catalogPackage?.GetApplicableInstaller(options);
-
-        if (installerInfo is not null)
-            source[package.GetHash()] = installerInfo;
-
-        return installerInfo;
+        // Return the Native Package
+        return SearchResult.Result.Matches.First().CatalogPackage;
     }
 }

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativePackageHandler.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativePackageHandler.cs
@@ -19,14 +19,14 @@ public static class NativePackageHandler
     /// <returns></returns>
     public static CatalogPackage? GetPackage(IPackage package)
     {
-        if (NativeWinGetHelper.ExternalFactory is null || NativeWinGetHelper.ExternalManager is null)
+        if (NativeWinGetHelper.ExternalFactory is null || NativeWinGetHelper.ExternalWinGetManager is null)
             return null;
 
         __nativePackages.TryGetValue(package.GetHash(), out CatalogPackage? catalogPackage);
         if (catalogPackage is not null)
             return catalogPackage;
 
-        PackageCatalogReference Catalog = NativeWinGetHelper.ExternalManager.GetPackageCatalogByName(package.Source.Name);
+        PackageCatalogReference Catalog = NativeWinGetHelper.ExternalWinGetManager.GetPackageCatalogByName(package.Source.Name);
         if (Catalog is null)
         {
             Logger.Error("Failed to get catalog " + package.Source.Name + ". Is the package local?");

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativePackageHandler.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativePackageHandler.cs
@@ -47,9 +47,9 @@ public static class NativePackageHandler
     /// Get (cached or load) the native package details for the given package, if any;
     /// </summary>
     public static CatalogPackageMetadata? GetDetails(IPackage package)
-        => TaskRecycler<CatalogPackageMetadata?>.RunOrAttach(_getDetails, package);
-
-    private static CatalogPackageMetadata? _getDetails(IPackage package)
+    //    => TaskRecycler<CatalogPackageMetadata?>.RunOrAttach(_getDetails, package);
+    //
+    //private static CatalogPackageMetadata? _getDetails(IPackage package)
     {
         if (__nativeDetails.TryGetValue(package.GetHash(), out CatalogPackageMetadata? metadata))
             return metadata;
@@ -68,9 +68,9 @@ public static class NativePackageHandler
     /// Get (cached or load) the native installer for the given package, if any. The operation type determines wether
     /// </summary>
     public static PackageInstallerInfo? GetInstallationOptions(IPackage package, OperationType operation)
-        =>  TaskRecycler<PackageInstallerInfo?>.RunOrAttach(_getInstallationOptions, package, operation);
-
-    private static PackageInstallerInfo? _getInstallationOptions(IPackage package, OperationType operation)
+    //    =>  TaskRecycler<PackageInstallerInfo?>.RunOrAttach(_getInstallationOptions, package, operation);
+    //
+    //private static PackageInstallerInfo? _getInstallationOptions(IPackage package, OperationType operation)
     {
         if (NativeWinGetHelper.ExternalFactory is null)
             return null;

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativeWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativeWinGetHelper.cs
@@ -192,7 +192,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
     {
         var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListInstalledPackages);
         List<Package> packages = [];
-        foreach (var nativePackage in TaskRecycler<IEnumerable<CatalogPackage>>.RunOrAttach(GetLocalWinGetPackages))
+        foreach (var nativePackage in TaskRecycler<IEnumerable<CatalogPackage>>.RunOrAttachOrCache(GetLocalWinGetPackages, 15))
         {
             IManagerSource source;
             if (nativePackage.DefaultInstallVersion is not null)

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativeWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativeWinGetHelper.cs
@@ -163,7 +163,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
     {
         var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListUpdates);
         List<Package> packages = [];
-        foreach (var nativePackage in GetLocalWinGetPackages(logger))
+        foreach (var nativePackage in TaskRecycler<IEnumerable<CatalogPackage>>.RunOrAttach(GetLocalWinGetPackages))
         {
             if (nativePackage.IsUpdateAvailable)
             {
@@ -192,7 +192,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
     {
         var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListInstalledPackages);
         List<Package> packages = [];
-        foreach (var nativePackage in GetLocalWinGetPackages(logger))
+        foreach (var nativePackage in TaskRecycler<IEnumerable<CatalogPackage>>.RunOrAttach(GetLocalWinGetPackages))
         {
             IManagerSource source;
             if (nativePackage.DefaultInstallVersion is not null)
@@ -219,7 +219,8 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
 
     private IEnumerable<CatalogPackage> GetLocalWinGetPackages()
     {
-        var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListUpdates);
+        var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.OtherTask);
+        logger.Log("OtherTask: GetWinGetLocalPackages");
         PackageCatalogReference installedSearchCatalogRef;
         CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = Factory.CreateCreateCompositePackageCatalogOptions();
         foreach (var catalogRef in WinGetManager.GetPackageCatalogs().ToArray())
@@ -252,6 +253,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
             foundPackages.Add(match.CatalogPackage);
         }
 
+        logger.Close(0);
         return foundPackages;
     }
 

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/BaseProviders/BaseSourceProvider.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/BaseProviders/BaseSourceProvider.cs
@@ -18,18 +18,32 @@ namespace UniGetUI.PackageEngine.Classes.Manager.Providers
 
         public abstract string[] GetAddSourceParameters(IManagerSource source);
         public abstract string[] GetRemoveSourceParameters(IManagerSource source);
-        public abstract OperationVeredict GetAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output);
-        public abstract OperationVeredict GetRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output);
+        protected abstract OperationVeredict _getAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output);
+        protected abstract OperationVeredict _getRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output);
+
+        public OperationVeredict GetAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        {
+            TaskRecycler<IEnumerable<IManagerSource>>.RemoveFromCache(_getSources);
+            return _getAddSourceOperationVeredict(source, ReturnCode, Output);
+        }
+
+        public OperationVeredict GetRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        {
+            TaskRecycler<IEnumerable<IManagerSource>>.RemoveFromCache(_getSources);
+            return _getRemoveSourceOperationVeredict(source, ReturnCode, Output);
+        }
+
+
 
         /// <summary>
         /// Loads the sources for the manager. This method SHOULD NOT handle exceptions
         /// </summary>
         protected abstract IEnumerable<IManagerSource> GetSources_UnSafe();
+
         public virtual IEnumerable<IManagerSource> GetSources()
-            => TaskRecycler<IEnumerable<IManagerSource>>.RunOrAttach(_getSources);
+            => TaskRecycler<IEnumerable<IManagerSource>>.RunOrAttachOrCache(_getSources, 15);
 
         public virtual IEnumerable<IManagerSource> _getSources()
-
         {
             IEnumerable<IManagerSource> sources = GetSources_UnSafe();
             SourceFactory.Reset();

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/BaseProviders/BaseSourceProvider.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/BaseProviders/BaseSourceProvider.cs
@@ -1,3 +1,4 @@
+using UniGetUI.Core.Classes;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageEngine.Interfaces.ManagerProviders;
@@ -25,6 +26,10 @@ namespace UniGetUI.PackageEngine.Classes.Manager.Providers
         /// </summary>
         protected abstract IEnumerable<IManagerSource> GetSources_UnSafe();
         public virtual IEnumerable<IManagerSource> GetSources()
+            => TaskRecycler<IEnumerable<IManagerSource>>.RunOrAttach(_getSources);
+
+        public virtual IEnumerable<IManagerSource> _getSources()
+
         {
             IEnumerable<IManagerSource> sources = GetSources_UnSafe();
             SourceFactory.Reset();

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/NullPackageManager.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/Classes/NullPackageManager.cs
@@ -225,12 +225,12 @@ namespace UniGetUI.PackageEngine.Classes.Manager
             throw new InvalidOperationException("Package manager does not support removing sources");
         }
 
-        public override OperationVeredict GetAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        protected override OperationVeredict _getAddSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
         {
             return OperationVeredict.Failed;
         }
 
-        public override OperationVeredict GetRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
+        protected override OperationVeredict _getRemoveSourceOperationVeredict(IManagerSource source, int ReturnCode, string[] Output)
         {
             return OperationVeredict.Failed;
         }

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/PackageManager.cs
@@ -188,6 +188,9 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
         /// This method is fail-safe and will return an empty array if an error occurs.
         /// </summary>
         public IEnumerable<IPackage> GetAvailableUpdates()
+        /*    => TaskRecycler<IEnumerable<IPackage>>.RunOrAttach(_getAvailableUpdates, Properties.Name.GetHashCode());
+
+        private IEnumerable<IPackage> _getAvailableUpdates(int _uselessParam)*/
         {
             if (!IsReady()) { Logger.Warn($"Manager {Name} is disabled but yet GetAvailableUpdates was called"); return []; }
             try
@@ -221,6 +224,9 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
         /// This method is fail-safe and will return an empty array if an error occurs.
         /// </summary>
         public IEnumerable<IPackage> GetInstalledPackages()
+        /*    => TaskRecycler<IEnumerable<IPackage>>.RunOrAttach(_getInstalledPackages, Properties.Name.GetHashCode());
+
+        private IEnumerable<IPackage> _getInstalledPackages(int _uselessParam)*/
         {
             if (!IsReady()) { Logger.Warn($"Manager {Name} is disabled but yet GetInstalledPackages was called"); return []; }
             try

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Classes/InstallationOptions.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Classes/InstallationOptions.cs
@@ -228,7 +228,6 @@ namespace UniGetUI.PackageEngine.PackageClasses
                 }
 
                 FromSerializable(options);
-                Logger.Debug($"InstallationOptions loaded successfully from disk for package {Package.Id}");
             }
             catch (JsonException)
             {

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Classes/InstallationOptions.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Classes/InstallationOptions.cs
@@ -54,7 +54,6 @@ namespace UniGetUI.PackageEngine.PackageClasses
             }
             else
             {
-                Logger.Debug($"Creating new instance of InstallationOptions for package {package}, as no instance was found in cache");
                 instance = new(package);
                 instance.LoadFromDisk();
                 OptionsCache.TryAdd(package.GetHash(), instance);

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using UniGetUI.Core.Classes;
 using UniGetUI.Core.IconEngine;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.Tools;
@@ -22,6 +23,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
         private readonly long __hash;
         private readonly long __versioned_hash;
         private readonly string ignoredId;
+        private readonly string _iconId;
 
         private bool IconHasBeenCached = false;
         private Uri? CachedIcon;
@@ -35,16 +37,12 @@ namespace UniGetUI.PackageEngine.PackageClasses
         public PackageTag Tag
         {
             get => __tag;
-            set
-            {
-                __tag = value;
-                OnPropertyChanged(nameof(Tag));
-            }
+            set { __tag = value; OnPropertyChanged(nameof(Tag)); }
         }
 
         public bool IsChecked
         {
-            get { return __is_checked; }
+            get => __is_checked;
             set { __is_checked = value; OnPropertyChanged(nameof(IsChecked)); }
         }
 
@@ -99,6 +97,14 @@ namespace UniGetUI.PackageEngine.PackageClasses
             IsUpgradable = false;
 
             ignoredId = IgnoredUpdatesDatabase.GetIgnoredIdForPackage(this);
+
+            _iconId = Manager.Name switch
+            {
+                "Winget" => string.Join('.', id.ToLower().Split(".")[1..]),
+                "Scoop" => id.ToLower().Replace(".app", ""),
+                "Chocolatey" => id.ToLower().Replace(".install", "").Replace(".portable", ""),
+                _ => id.ToLower()
+            };
         }
 
         /// <summary>
@@ -123,24 +129,16 @@ namespace UniGetUI.PackageEngine.PackageClasses
         }
 
         public long GetHash()
-        {
-            return __hash;
-        }
+            => __hash;
 
         public long GetVersionedHash()
-        {
-            return __versioned_hash;
-        }
+            => __versioned_hash;
 
         public bool Equals(IPackage? other)
-        {
-            return __versioned_hash == other?.GetHash();
-        }
+            => __versioned_hash == other?.GetHash();
 
         public override int GetHashCode()
-        {
-            return (int)__versioned_hash;
-        }
+            => (int)__versioned_hash;
 
         /// <summary>
         /// Check whether two package instances represent the same package.
@@ -152,29 +150,10 @@ namespace UniGetUI.PackageEngine.PackageClasses
         /// <param name="other">A package</param>
         /// <returns>Whether the two instances refer to the same instance</returns>
         public bool IsEquivalentTo(IPackage? other)
-        {
-            return __hash == other?.GetHash();
-        }
+            => __hash == other?.GetHash();
 
         public string GetIconId()
-        {
-            string iconId = Id.ToLower();
-            if (Manager.Name == "Winget")
-            {
-                iconId = string.Join('.', iconId.Split(".")[1..]);
-            }
-            else if (Manager.Name == "Chocolatey")
-            {
-                iconId = iconId.Replace(".install", "").Replace(".portable", "");
-            }
-            else if (Manager.Name == "Scoop")
-            {
-                iconId = iconId.Replace(".app", "");
-            }
-
-            Logger.Debug($"Icon id for package={Id} is {iconId}");
-            return iconId;
-        }
+            => _iconId;
 
         public virtual Uri GetIconUrl()
         {
@@ -185,7 +164,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
         {
             if (!IconHasBeenCached)
             {
-                CachedIcon = LoadIconUrlIfAny();
+                CachedIcon = TaskRecycler<Uri?>.RunOrAttachOrCache(LoadIconUrlIfAny, 30);
                 IconHasBeenCached = true;
             }
 
@@ -287,19 +266,13 @@ namespace UniGetUI.PackageEngine.PackageClasses
         }
 
         public IPackage? GetInstalledPackage()
-        {
-            return PackageCacher.GetInstalledPackageOrNull(this);
-        }
+            => PackageCacher.GetInstalledPackageOrNull(this);
 
         public IPackage? GetAvailablePackage()
-        {
-            return PackageCacher.GetAvailablePackageOrNull(this);
-        }
+            => PackageCacher.GetAvailablePackageOrNull(this);
 
         public IPackage? GetUpgradablePackage()
-        {
-            return PackageCacher.GetUpgradablePackageOrNull(this);
-        }
+            => PackageCacher.GetUpgradablePackageOrNull(this);
 
         public virtual void SetTag(PackageTag tag)
         {
@@ -309,9 +282,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
         public virtual bool NewerVersionIsInstalled()
         {
             if (!IsUpgradable)
-            {
                 return false;
-            }
 
             return PackageCacher.NewerVersionIsInstalled(this);
         }


### PR DESCRIPTION
The `TaskRecycler` class will help prevent calling twice a CPU-intensive method, when the method could be called only once and the result shared with all the callers. This will help reduce CPU usage on methods that are supposed to return the same results when called with little to no time difference. 

An example: The following threads call Manager.GetInstalledPackages, and are likely to do so at the same time.
```csharp

Thread 1:
	var installed = Manager.GetInstalledPackages();

Thread 2:
	var upgrades = Manager.GetInstalledPackages().where(p => p.IsUpgradable);
```

To optimize this, the following can be done.

```csharp
Thread 1:
	var installed = TaskRecycler<IEnumerable<Package>>.RunOrAttachAsync(Manager.GetInstalledPackages);

Thread 2:
	var upgrades = TaskRecycler<IEnumerable<Package>>.RunOrAttachAsync(Manager.GetInstalledPackages).where(p => p.IsUpgradable);
```
This code will execute as the code above, with the difference that if `Manager.GetInstalledPackages` is called when another call to `Manager.GetInstalledPackages` is running, the result of the first call of `Manager.GetInstalledPackages` will be used instead of calling the method twice.

Fixes some of the TODOs on #2932