### PR TITLE
Improvements to icons

### DIFF
--- a/src/UniGetUI.Core.Classes.Tests/TaskRecyclerTests.cs
+++ b/src/UniGetUI.Core.Classes.Tests/TaskRecyclerTests.cs
@@ -56,16 +56,16 @@ public class TaskRecyclerTests
     public void TestTaskRecycler_Static_Int_WithCache()
     {
         // The same static method should be cached, and therefore the return value should be the same
-        var task1 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
-        var task2 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
+        var task1 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod1, 2);
+        var task2 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod1, 2);
         int result1 = task1.GetAwaiter().GetResult();
         int result2 = task2.GetAwaiter().GetResult();
         Assert.Equal(result1, result2);
 
         // The same static method should be cached, and therefore the return value should be the same,
         // and equal to previous runs due to 3 seconds cache
-        var task3 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
-        var task4 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
+        var task3 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod1, 2);
+        var task4 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod1, 2);
         int result4 = task4.GetAwaiter().GetResult();
         int result3 = task3.GetAwaiter().GetResult();
         Assert.Equal(result3, result4);
@@ -75,8 +75,8 @@ public class TaskRecyclerTests
         Thread.Sleep(3000);
 
         // The same static method should be cached, but cached runs should have been removed. This results should differ from previous ones
-        var task5 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
-        var task6 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
+        var task5 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod1, 2);
+        var task6 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod1, 2);
         int result5 = task6.GetAwaiter().GetResult();
         int result6 = task5.GetAwaiter().GetResult();
         Assert.Equal(result5, result6);
@@ -86,8 +86,8 @@ public class TaskRecyclerTests
         TaskRecycler<int>.RemoveFromCache(MySlowMethod1);
 
         // The same static method should be cached, but cached runs should have been cleared manually. This results should differ from previous ones
-        var task7 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
-        var task8 = TaskRecycler<int>.RunOrAttachOrCacheAsync(MySlowMethod1, 2);
+        var task7 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod1, 2);
+        var task8 = TaskRecycler<int>.RunOrAttachAsync(MySlowMethod1, 2);
         int result7 = task7.GetAwaiter().GetResult();
         int result8 = task8.GetAwaiter().GetResult();
         Assert.Equal(result7, result8);

--- a/src/UniGetUI.Core.Classes/TaskRecycler.cs
+++ b/src/UniGetUI.Core.Classes/TaskRecycler.cs
@@ -23,89 +23,120 @@ public static class TaskRecycler<ReturnT>
 {
     private static ConcurrentDictionary<int, Task<ReturnT>> _tasks = new();
 
-    /*
-     * Method definitions
-     */
-    public static async Task<ReturnT> RunOrAttachAsync(Func<ReturnT> method, int cacheTimeSecs = 0)
+
+    // ---------------------------------------------------------------------------------------------------------------
+
+
+    /// Asynchronous entry point for 0 parameters
+    public static Task<ReturnT> RunOrAttachAsync(Func<ReturnT> method, int cacheTimeSecs = 0)
     {
         int hash = method.GetHashCode();
-
-        var existingTask = _getExistingTaskIfAny(hash);
-        Logger.Debug($"[TaskRecycler] Deduplicated one call to {method.Method.Name}");
-        return await (existingTask ?? _runTaskAndWait(Task.Run(method), hash, cacheTimeSecs));
+        return _runTaskAndWait(new Task<ReturnT>(method), hash, cacheTimeSecs);
     }
 
-    public static async Task<ReturnT> RunOrAttachAsync<ParamT>(Func<ParamT, ReturnT> method, ParamT arg1, int cacheTimeSecs = 0)
+    /// Asynchronous entry point for 1 parameter
+    public static Task<ReturnT> RunOrAttachAsync<ParamT>(Func<ParamT, ReturnT> method, ParamT arg1, int cacheTimeSecs = 0)
     {
         int hash = method.GetHashCode() + (arg1?.GetHashCode() ?? 0);
-        return await (_getExistingTaskIfAny(hash) ?? _runTaskAndWait(Task.Run(() => method(arg1)), hash, cacheTimeSecs));
+        return _runTaskAndWait(new Task<ReturnT>(() => method(arg1)), hash, cacheTimeSecs);
     }
 
-    public static async Task<ReturnT> RunOrAttachAsync<Param1T, Param2T>(Func<Param1T, Param2T, ReturnT> method,
+    /// Asynchronous entry point for 2 parameters
+    public static Task<ReturnT> RunOrAttachAsync<Param1T, Param2T>(Func<Param1T, Param2T, ReturnT> method,
         Param1T arg1, Param2T arg2, int cacheTimeSecs = 0)
     {
         int hash = method.GetHashCode() + (arg1?.GetHashCode() ?? 0) + (arg2?.GetHashCode() ?? 0);
-        return await (_getExistingTaskIfAny(hash) ?? _runTaskAndWait(Task.Run(() => method(arg1, arg2)), hash, cacheTimeSecs));
+        return _runTaskAndWait(new Task<ReturnT>(() => method(arg1, arg2)), hash, cacheTimeSecs);
     }
 
-    public static async Task<ReturnT> RunOrAttachAsync<Param1T, Param2T, Param3T>(Func<Param1T, Param2T, Param3T, ReturnT> method,
+    /// Asynchronous entry point for 3 parameters
+    public static Task<ReturnT> RunOrAttachAsync<Param1T, Param2T, Param3T>(Func<Param1T, Param2T, Param3T, ReturnT> method,
         Param1T arg1, Param2T arg2, Param3T arg3, int cacheTimeSecs = 0)
     {
         int hash = method.GetHashCode() + (arg1?.GetHashCode() ?? 0) + (arg2?.GetHashCode() ?? 0) + (arg3?.GetHashCode() ?? 0);
-        return await (_getExistingTaskIfAny(hash) ?? _runTaskAndWait(Task.Run(() => method(arg1, arg2, arg3)), hash, cacheTimeSecs));
+        return _runTaskAndWait(new Task<ReturnT>(() => method(arg1, arg2, arg3)), hash, cacheTimeSecs);
     }
 
 
-    /*
-     * Synchronous wrappers for methods defined above
-     */
+    // ---------------------------------------------------------------------------------------------------------------
+
+
+    /// Synchronous entry point for 0 parameters
     public static ReturnT RunOrAttach(Func<ReturnT> method, int cacheTimeSecs = 0)
         => RunOrAttachAsync(method, cacheTimeSecs).GetAwaiter().GetResult();
 
+    /// Synchronous entry point for 1 parameter1
     public static ReturnT RunOrAttach<ParamT>(Func<ParamT, ReturnT> method, ParamT arg1, int cacheTimeSecs = 0)
         => RunOrAttachAsync(method, arg1, cacheTimeSecs).GetAwaiter().GetResult();
 
+    /// Synchronous entry point for 2 parameters
     public static ReturnT RunOrAttach<Param1T, Param2T>(Func<Param1T, Param2T, ReturnT> method, Param1T arg1,
         Param2T arg2, int cacheTimeSecs = 0)
         => RunOrAttachAsync(method, arg1, arg2, cacheTimeSecs).GetAwaiter().GetResult();
 
+    /// Synchronous entry point for 3 parameters
     public static ReturnT RunOrAttach<Param1T, Param2T, Param3T>(Func<Param1T, Param2T, Param3T, ReturnT> method, Param1T arg1,
         Param2T arg2, Param3T arg3, int cacheTimeSecs = 0)
         => RunOrAttachAsync(method, arg1, arg2, arg3, cacheTimeSecs).GetAwaiter().GetResult();
 
 
-    /*
-     * No-argment entries for cached calls
-     */
+    // ---------------------------------------------------------------------------------------------------------------
+
+
+    /// <summary>
+    /// Instantly removes a function call from the cache, even if the associated task has not
+    /// finished yet. Any previous call will finish as expected. New calls won't attach to any
+    /// preexisting Tasks, and a new Task will be created instead.
+    /// If the given function call is not present in the cache, nothing will be done.
+    /// </summary>
+    /// <param name="method"></param>
     public static void RemoveFromCache(Func<ReturnT> method)
         => _removeFromCache(method.GetHashCode(), 0);
 
 
-    /*
-     * Internal methods used to cache and retrieve tasks
-     */
-    private static Task<ReturnT>? _getExistingTaskIfAny(int hash)
-    {
-        _tasks.TryGetValue(hash, out Task<ReturnT>? currentTask);
-        return currentTask;
-    }
+    // ---------------------------------------------------------------------------------------------------------------
 
-    private static async Task<ReturnT> _runTaskAndWait(Task<ReturnT> task, int hash, int cacheTimeSecsSecs = 0)
+
+    /// <summary>
+    /// Handles running the task if no such task was found on cache, and returning the cached task if it was found.
+    /// </summary>
+    private static async Task<ReturnT> _runTaskAndWait(Task<ReturnT> task, int hash, int cacheTimeSecsSecs)
     {
-        _tasks[hash] = task;
-        /* BEGIN WAIT */
+        if (_tasks.TryGetValue(hash, out Task<ReturnT>? _task))
+        {
+            // Get the cached task, which is either running or finished
+            task = _task;
+        }
+        else if (!_tasks.TryAdd(hash, task))
+        {
+            // Race condition, an equivalent task got added from another thread between the TryGetValue and TryAdd,
+            // so we are going to restart the call to _runTaskAndWait in order for TryGetValue to return the new task again
+            return await _runTaskAndWait(task, hash, cacheTimeSecsSecs);
+        }
+        else
+        {
+            // Now that the new task is in the cache, run the task.
+            task.Start();
+        }
+
+        // Wait for the task to finish
         ReturnT result = await task;
 
-        /* END WAIT, AND REMOVE FROM CACHE WHEN ASKED  */
-        if (cacheTimeSecsSecs is 0) _tasks.Remove(hash, out _);
-        else _removeFromCache(hash, cacheTimeSecsSecs);
+        // Schedule the task for removal after the cache time expires
+        _removeFromCache(hash, cacheTimeSecsSecs);
 
         return result;
     }
 
+    /// <summary>
+    /// Removes the task associated with the given hash from the cache after the given period of time
+    /// If the given hash is not present, nothing will be done.
+    /// </summary>
     private static async void _removeFromCache(int hash, int cacheTimeSecsSecs)
     {
-        await Task.Delay(cacheTimeSecsSecs * 1000);
+        if(cacheTimeSecsSecs > 0)
+            await Task.Delay(cacheTimeSecsSecs * 1000);
+
         _tasks.Remove(hash, out _);
     }
 }

--- a/src/UniGetUI.Core.Data/Licenses.cs
+++ b/src/UniGetUI.Core.Data/Licenses.cs
@@ -11,6 +11,7 @@ namespace UniGetUI.Core.Data
             {"H.NotifyIcon",            "MIT"},
             {"Windows App Sdk",         "MIT"},
             {"NancyFx",                 "MIT"},
+            {"PhotoSauce.MagicScaler",  "MIT"},
             {"YamlDotNet",              "MIT"},
             {"InnoDependencyInstaller", "CPOL 1.02" },
 
@@ -40,6 +41,7 @@ namespace UniGetUI.Core.Data
             {"H.NotifyIcon",            new Uri("https://github.com/HavenDV/H.NotifyIcon/blob/master/LICENSE.md")},
             {"Windows App Sdk",         new Uri("https://github.com/microsoft/WindowsAppSDK/blob/main/LICENSE")},
             {"NancyFx",                 new Uri("https://github.com/NancyFx/Nancy/blob/master/license.txt")},
+            {"PhotoSauce.MagicScaler",  new Uri("https://github.com/saucecontrol/PhotoSauce/blob/master/license")},
             {"YamlDotNet",              new Uri("https://github.com/aaubry/YamlDotNet/blob/master/LICENSE.txt") },
             {"InnoDependencyInstaller", new Uri("https://github.com/DomGries/InnoDependencyInstaller/blob/master/LICENSE.md") },
 
@@ -69,6 +71,7 @@ namespace UniGetUI.Core.Data
             {"H.NotifyIcon",            new Uri("https://github.com/HavenDV/H.NotifyIcon/")},
             {"Windows App Sdk",         new Uri("https://github.com/microsoft/WindowsAppSDK/")},
             {"NancyFx",                 new Uri("https://github.com/NancyFx/Nancy/")},
+            {"PhotoSauce.MagicScaler",  new Uri("https://github.com/saucecontrol/PhotoSauce/")},
             {"YamlDotNet",              new Uri("https://github.com/aaubry/YamlDotNet/") },
             {"InnoDependencyInstaller", new Uri("https://github.com/DomGries/InnoDependencyInstaller")},
 

--- a/src/UniGetUI.Core.IconEngine.Tests/IconCacheEngineTests.cs
+++ b/src/UniGetUI.Core.IconEngine.Tests/IconCacheEngineTests.cs
@@ -24,7 +24,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Download a hashed icon
             CacheableIcon icon = new(ICON_1, HASH_1);
-            string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId, 0);
             Assert.NotNull(path);
             Assert.Equal(expectedFile, path);
             Assert.True(File.Exists(path));
@@ -33,7 +33,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Test the same icon, modification date shouldn't change
             icon = new CacheableIcon(ICON_1, HASH_1);
-            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId, 0);
             Assert.NotNull(path);
             DateTime newModificationDate = File.GetLastWriteTime(path);
 
@@ -43,7 +43,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Attempt to retrieve a different icon. The modification date SHOULD have changed
             icon = new CacheableIcon(ICON_2, HASH_2);
-            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId, 0);
             Assert.NotNull(path);
             DateTime newIconModificationDate = File.GetLastWriteTime(path);
 
@@ -53,7 +53,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Give an invalid hash: The icon should not be cached not returned
             icon = new CacheableIcon(ICON_2, HASH_1);
-            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId, 0);
             Assert.Null(path);
             Assert.False(File.Exists(path));
         }
@@ -75,7 +75,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Download an icon through version verification
             CacheableIcon icon = new(URI, VERSION);
-            string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, MANAGER_NAME, PACKAGE_ID);
+            string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, MANAGER_NAME, PACKAGE_ID, 0);
             Assert.NotNull(path);
             Assert.Equal(expectedFile, path);
             Assert.True(File.Exists(path));
@@ -84,7 +84,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Test the same version, the icon should not get touched
             icon = new CacheableIcon(URI, VERSION);
-            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, MANAGER_NAME, PACKAGE_ID);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, MANAGER_NAME, PACKAGE_ID, 0);
             Assert.NotNull(path);
             DateTime newModificationDate = File.GetLastWriteTime(path);
 
@@ -94,7 +94,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Test a new version, the icon should be downloaded again
             icon = new CacheableIcon(URI, VERSION + "-beta0");
-            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, MANAGER_NAME, PACKAGE_ID);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, MANAGER_NAME, PACKAGE_ID, 0);
             Assert.NotNull(path);
             DateTime newNewModificationDate = File.GetLastWriteTime(path);
 
@@ -120,7 +120,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Download an icon through URI verification
             CacheableIcon icon = new(URI_1);
-            string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId, 0);
             Assert.NotNull(path);
             Assert.Equal(expectedFile, path);
             Assert.True(File.Exists(path));
@@ -129,7 +129,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Test the same URI, the icon should not get touched
             icon = new CacheableIcon(URI_1);
-            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId, 0);
             Assert.NotNull(path);
             DateTime newModificationDate = File.GetLastWriteTime(path);
 
@@ -139,7 +139,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Test a new URI, the icon should be downloaded again
             icon = new CacheableIcon(URI_2);
-            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId, 0);
             Assert.NotNull(path);
             DateTime newNewModificationDate = File.GetLastWriteTime(path);
 
@@ -168,7 +168,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Cache an icon
             CacheableIcon icon = new(ICON_1, ICON_1_SIZE);
-            string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId, 0);
             Assert.NotNull(path);
             Assert.Equal(expectedFile, path);
             Assert.True(File.Exists(path));
@@ -177,7 +177,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Attempt to retrieve the same icon again.
             icon = new CacheableIcon(ICON_1, ICON_1_SIZE);
-            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId, 0);
             Assert.NotNull(path);
             DateTime newModificationDate = File.GetLastWriteTime(path);
 
@@ -188,7 +188,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Attempt to retrieve a different icon. The modification date SHOULD have changed
             icon = new CacheableIcon(ICON_2, ICON_2_SIZE);
-            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId, 0);
             Assert.NotNull(path);
             DateTime newIconModificationDate = File.GetLastWriteTime(path);
 
@@ -198,7 +198,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Give an invalid size: The icon should not be cached not returned
             icon = new CacheableIcon(ICON_1, ICON_1_SIZE + 1);
-            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId, 0);
             Assert.Null(path);
             Assert.False(File.Exists(path));
         }

--- a/src/UniGetUI.Core.IconEngine.Tests/IconCacheEngineTests.cs
+++ b/src/UniGetUI.Core.IconEngine.Tests/IconCacheEngineTests.cs
@@ -5,7 +5,7 @@ namespace UniGetUI.Core.IconEngine.Tests
     public static class IconCacheEngineTests
     {
         [Fact]
-        public static async Task TestCacheEngineForSha256()
+        public static void TestCacheEngineForSha256()
         {
             Uri ICON_1 = new Uri("https://marticliment.com/resources/wingetui.png");
             byte[] HASH_1 = [0x24, 0x4e, 0x42, 0xb6, 0xbe, 0x44, 0x04, 0x66, 0xc8, 0x77, 0xf7, 0x68, 0x8a, 0xe0, 0xa9, 0x45, 0xfb, 0x2e, 0x66, 0x8c, 0x41, 0x84, 0x1f, 0x2d, 0x10, 0xcf, 0x92, 0xd4, 0x0d, 0x8c, 0xbb, 0xf6];
@@ -16,7 +16,7 @@ namespace UniGetUI.Core.IconEngine.Tests
             string packageId = "Package55";
 
             string extension = ICON_1.ToString().Split(".")[^1];
-            string expectedFile = Path.Join(CoreData.UniGetUICacheDirectory_Icons, managerName, packageId + "." + extension);
+            string expectedFile = Path.Join(CoreData.UniGetUICacheDirectory_Icons, managerName, packageId, $"icon.{extension}");
             if (File.Exists(expectedFile))
             {
                 File.Delete(expectedFile);
@@ -24,7 +24,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Download a hashed icon
             CacheableIcon icon = new(ICON_1, HASH_1);
-            string? path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
             Assert.NotNull(path);
             Assert.Equal(expectedFile, path);
             Assert.True(File.Exists(path));
@@ -33,7 +33,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Test the same icon, modification date shouldn't change
             icon = new CacheableIcon(ICON_1, HASH_1);
-            path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
             Assert.NotNull(path);
             DateTime newModificationDate = File.GetLastWriteTime(path);
 
@@ -43,7 +43,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Attempt to retrieve a different icon. The modification date SHOULD have changed
             icon = new CacheableIcon(ICON_2, HASH_2);
-            path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
             Assert.NotNull(path);
             DateTime newIconModificationDate = File.GetLastWriteTime(path);
 
@@ -53,25 +53,29 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Give an invalid hash: The icon should not be cached not returned
             icon = new CacheableIcon(ICON_2, HASH_1);
-            path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
             Assert.Null(path);
             Assert.False(File.Exists(path));
         }
 
-        [Theory]
-        [InlineData("https://marticliment.com/resources/wingetui.png", "v3.01", "TestManager", "Package2")]
-        public static async Task TestCacheEngineForPackageVersion(string url, string version, string managerName, string packageId)
+        [Fact]
+        public static void TestCacheEngineForPackageVersion()
         {
-            string extension = url.Split(".")[^1];
-            string expectedFile = Path.Join(CoreData.UniGetUICacheDirectory_Icons, managerName, packageId + "." + extension);
+            Uri URI = new Uri("https://marticliment.com/resources/wingetui.png");
+            string VERSION = "v3.01";
+            string MANAGER_NAME = "TestManager";
+            string PACKAGE_ID = "Package2";
+
+            string extension = URI.ToString().Split(".")[^1];
+            string expectedFile = Path.Join(CoreData.UniGetUICacheDirectory_Icons, MANAGER_NAME, PACKAGE_ID, $"icon.{extension}");
             if (File.Exists(expectedFile))
             {
                 File.Delete(expectedFile);
             }
 
             // Download an icon through version verification
-            CacheableIcon icon = new(new Uri(url), version);
-            string? path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            CacheableIcon icon = new(URI, VERSION);
+            string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, MANAGER_NAME, PACKAGE_ID);
             Assert.NotNull(path);
             Assert.Equal(expectedFile, path);
             Assert.True(File.Exists(path));
@@ -79,8 +83,8 @@ namespace UniGetUI.Core.IconEngine.Tests
             DateTime oldModificationDate = File.GetLastWriteTime(path);
 
             // Test the same version, the icon should not get touched
-            icon = new CacheableIcon(new Uri(url), version);
-            path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            icon = new CacheableIcon(URI, VERSION);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, MANAGER_NAME, PACKAGE_ID);
             Assert.NotNull(path);
             DateTime newModificationDate = File.GetLastWriteTime(path);
 
@@ -89,8 +93,8 @@ namespace UniGetUI.Core.IconEngine.Tests
             Assert.True(File.Exists(path));
 
             // Test a new version, the icon should be downloaded again
-            icon = new CacheableIcon(new Uri(url), version + "-beta0");
-            path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            icon = new CacheableIcon(URI, VERSION + "-beta0");
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, MANAGER_NAME, PACKAGE_ID);
             Assert.NotNull(path);
             DateTime newNewModificationDate = File.GetLastWriteTime(path);
 
@@ -100,7 +104,7 @@ namespace UniGetUI.Core.IconEngine.Tests
         }
 
         [Fact]
-        public static async Task TestCacheEngineForIconUri()
+        public static void TestCacheEngineForIconUri()
         {
             Uri URI_1 = new Uri("https://marticliment.com/resources/wingetui.png");
             Uri URI_2 = new Uri("https://marticliment.com/resources/elevenclock.png");
@@ -108,7 +112,7 @@ namespace UniGetUI.Core.IconEngine.Tests
             string packageId = "Package12";
 
             string extension = URI_1.ToString().Split(".")[^1];
-            string expectedFile = Path.Join(CoreData.UniGetUICacheDirectory_Icons, managerName, packageId + "." + extension);
+            string expectedFile = Path.Join(CoreData.UniGetUICacheDirectory_Icons, managerName, packageId, $"icon.{extension}");
             if (File.Exists(expectedFile))
             {
                 File.Delete(expectedFile);
@@ -116,7 +120,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Download an icon through URI verification
             CacheableIcon icon = new(URI_1);
-            string? path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
             Assert.NotNull(path);
             Assert.Equal(expectedFile, path);
             Assert.True(File.Exists(path));
@@ -125,7 +129,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Test the same URI, the icon should not get touched
             icon = new CacheableIcon(URI_1);
-            path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
             Assert.NotNull(path);
             DateTime newModificationDate = File.GetLastWriteTime(path);
 
@@ -135,7 +139,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Test a new URI, the icon should be downloaded again
             icon = new CacheableIcon(URI_2);
-            path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
             Assert.NotNull(path);
             DateTime newNewModificationDate = File.GetLastWriteTime(path);
 
@@ -145,7 +149,7 @@ namespace UniGetUI.Core.IconEngine.Tests
         }
 
         [Fact]
-        public static async Task TestCacheEngineForPackageSize()
+        public static void TestCacheEngineForPackageSize()
         {
             Uri ICON_1 = new Uri("https://marticliment.com/resources/wingetui.png");
             int ICON_1_SIZE = 47903;
@@ -156,7 +160,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Clear any cache for reproducable data
             string extension = ICON_1.ToString().Split(".")[^1];
-            string expectedFile = Path.Join(CoreData.UniGetUICacheDirectory_Icons, managerName, packageId + "." + extension);
+            string expectedFile = Path.Join(CoreData.UniGetUICacheDirectory_Icons, managerName, packageId, $"icon.{extension}");
             if (File.Exists(expectedFile))
             {
                 File.Delete(expectedFile);
@@ -164,7 +168,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Cache an icon
             CacheableIcon icon = new(ICON_1, ICON_1_SIZE);
-            string? path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
             Assert.NotNull(path);
             Assert.Equal(expectedFile, path);
             Assert.True(File.Exists(path));
@@ -173,7 +177,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Attempt to retrieve the same icon again.
             icon = new CacheableIcon(ICON_1, ICON_1_SIZE);
-            path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
             Assert.NotNull(path);
             DateTime newModificationDate = File.GetLastWriteTime(path);
 
@@ -184,7 +188,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Attempt to retrieve a different icon. The modification date SHOULD have changed
             icon = new CacheableIcon(ICON_2, ICON_2_SIZE);
-            path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
             Assert.NotNull(path);
             DateTime newIconModificationDate = File.GetLastWriteTime(path);
 
@@ -194,7 +198,7 @@ namespace UniGetUI.Core.IconEngine.Tests
 
             // Give an invalid size: The icon should not be cached not returned
             icon = new CacheableIcon(ICON_1, ICON_1_SIZE + 1);
-            path = await IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
+            path = IconCacheEngine.GetCacheOrDownloadIcon(icon, managerName, packageId);
             Assert.Null(path);
             Assert.False(File.Exists(path));
         }

--- a/src/UniGetUI.Core.IconStore/IconCacheEngine.cs
+++ b/src/UniGetUI.Core.IconStore/IconCacheEngine.cs
@@ -39,7 +39,7 @@ namespace UniGetUI.Core.IconEngine
             Url = uri;
             this.SHA256 = Sha256;
             ValidationMethod = IconValidationMethod.SHA256;
-            _hashCode = uri.ToString().GetHashCode();
+            _hashCode = uri.ToString().GetHashCode() + Sha256[0] + Sha256[1] + Sha256[2] + Sha256[3];
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace UniGetUI.Core.IconEngine
             Url = uri;
             Version = version;
             ValidationMethod = IconValidationMethod.PackageVersion;
-            _hashCode = uri.ToString().GetHashCode();
+            _hashCode = uri.ToString().GetHashCode() + version.GetHashCode();
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace UniGetUI.Core.IconEngine
             Url = uri;
             Size = size;
             ValidationMethod = IconValidationMethod.FileSize;
-            _hashCode = uri.ToString().GetHashCode();
+            _hashCode = uri.ToString().GetHashCode() + (int)size;
         }
 
         /// <summary>
@@ -93,9 +93,10 @@ namespace UniGetUI.Core.IconEngine
         /// <param name="icon">a CacheableIcon object representing the object</param>
         /// <param name="ManagerName">The name of the PackageManager</param>
         /// <param name="PackageId">the Id of the package</param>
+        /// <param name="cacheInterval">the Time to store the icons on the TaskRecycler cache</param>
         /// <returns>A path to a local icon file</returns>
-        public static string? GetCacheOrDownloadIcon(CacheableIcon? icon, string ManagerName, string PackageId)
-            => TaskRecycler<string?>.RunOrAttach(_getCacheOrDownloadIcon, icon, ManagerName, PackageId, 30);
+        public static string? GetCacheOrDownloadIcon(CacheableIcon? icon, string ManagerName, string PackageId, int cacheInterval = 30)
+            => TaskRecycler<string?>.RunOrAttach(_getCacheOrDownloadIcon, icon, ManagerName, PackageId, cacheInterval);
 
         private static string? _getCacheOrDownloadIcon(CacheableIcon? _icon, string ManagerName, string PackageId)
         {

--- a/src/UniGetUI.Core.IconStore/UniGetUI.Core.IconEngine.csproj
+++ b/src/UniGetUI.Core.IconStore/UniGetUI.Core.IconEngine.csproj
@@ -32,4 +32,9 @@
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs" Link="SharedAssemblyInfo.cs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.14.2" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.10" />
+  </ItemGroup>
 </Project>

--- a/src/UniGetUI.Interface.BackgroundApi/BackgroundApi.cs
+++ b/src/UniGetUI.Interface.BackgroundApi/BackgroundApi.cs
@@ -192,7 +192,7 @@ namespace UniGetUI.Interface
 
                 while (PEInterface.UpgradablePackagesLoader.IsLoading)
                 {
-                    await Task.Delay(500); // Wait for the updates to be reported before showing anything
+                    await Task.Delay(100); // Wait for the updates to be reported before showing anything
                 }
 
                 StringBuilder packages = new();

--- a/src/UniGetUI.Interface.BackgroundApi/BackgroundApi.cs
+++ b/src/UniGetUI.Interface.BackgroundApi/BackgroundApi.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Web;
 using Nancy;
 using Nancy.Hosting.Self;
 using UniGetUI.Core.Data;
@@ -201,7 +202,7 @@ namespace UniGetUI.Interface
                         continue; // Do not show already processed packages on queue
                     }
 
-                    string icon = $"http://localhost:7058/widgets/v2/get_icon_for_package?packageId={package.Id}&packageSource={package.Source.Name}&token={ApiTokenHolder.Token}";
+                    string icon = $"http://localhost:7058/widgets/v2/get_icon_for_package?packageId={package.Id}&packageSource={HttpUtility.UrlEncode(package.Source.Name)}&token={ApiTokenHolder.Token}";
                     packages.Append($"{package.Name.Replace('|', '-')}|{package.Id}|{package.Version}|{package.NewVersion}|{package.Source.AsString_DisplayName}|{package.Manager.Name}|{icon}&&");
                 }
 

--- a/src/UniGetUI.Interface.BackgroundApi/BackgroundApi.cs
+++ b/src/UniGetUI.Interface.BackgroundApi/BackgroundApi.cs
@@ -3,6 +3,7 @@ using System.Web;
 using Nancy;
 using Nancy.Hosting.Self;
 using UniGetUI.Core.Data;
+using UniGetUI.Core.IconEngine;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
@@ -308,7 +309,10 @@ namespace UniGetUI.Interface
                     Uri iconUrl = await Task.Run(package.GetIconUrl);
                     if (iconUrl.ToString() != "ms-appx:///Assets/Images/package_color.png")
                     {
-                        iconPath = Path.Join(CoreData.UniGetUICacheDirectory_Icons, package.Manager.Name, $"{package.Id}.{iconUrl.ToString().Split('.')[^1]}");
+                        string mimePath = Path.Join(CoreData.UniGetUICacheDirectory_Icons, package.Manager.Name,
+                            package.Id, "icon.mime");
+                        iconPath = Path.Join(CoreData.UniGetUICacheDirectory_Icons, package.Manager.Name, package.Id,
+                            $"icon.{IconCacheEngine.MimeToExtension[await File.ReadAllTextAsync(mimePath)]}");
                     }
                     // else, the iconPath will be the preloaded one (package_color.png)
                 }
@@ -320,7 +324,7 @@ namespace UniGetUI.Interface
                 byte[] fileContents = await File.ReadAllBytesAsync(iconPath);
                 return new Response
                 {
-                    ContentType = $"image/{iconPath.Split('.')[^1]}",
+                    ContentType = IconCacheEngine.ExtensionToMime[iconPath.Split('.')[^1]],
                     Contents = (stream) =>
                     {
                         try

--- a/src/UniGetUI.Interface.BackgroundApi/BackgroundApi.cs
+++ b/src/UniGetUI.Interface.BackgroundApi/BackgroundApi.cs
@@ -196,14 +196,12 @@ namespace UniGetUI.Interface
                 }
 
                 StringBuilder packages = new();
-                foreach (Package package in PEInterface.UpgradablePackagesLoader.Packages)
+                foreach (IPackage package in PEInterface.UpgradablePackagesLoader.Packages)
                 {
                     if (package.Tag is PackageTag.OnQueue or PackageTag.BeingProcessed)
-                    {
                         continue; // Do not show already processed packages on queue
-                    }
 
-                    string icon = $"http://localhost:7058/widgets/v2/get_icon_for_package?packageId={package.Id}&packageSource={HttpUtility.UrlEncode(package.Source.Name)}&token={ApiTokenHolder.Token}";
+                    string icon = $"http://localhost:7058/widgets/v2/get_icon_for_package?packageId={HttpUtility.UrlEncode(package.Id)}&packageSource={HttpUtility.UrlEncode(package.Source.Name)}&token={ApiTokenHolder.Token}";
                     packages.Append($"{package.Name.Replace('|', '-')}|{package.Id}|{package.Version}|{package.NewVersion}|{package.Source.AsString_DisplayName}|{package.Manager.Name}|{icon}&&");
                 }
 

--- a/src/UniGetUI.PackageEngine.Managers.Cargo/Cargo.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Cargo/Cargo.cs
@@ -144,7 +144,7 @@ public partial class Cargo : PackageManager
     private IEnumerable<Package> GetPackages(LoggableTaskType taskType)
     {
         List<Package> Packages = [];
-        foreach(var match in TaskRecycler<List<Match>>.RunOrAttachOrCache(GetInstalledCommandOutput, 15))
+        foreach(var match in TaskRecycler<List<Match>>.RunOrAttach(GetInstalledCommandOutput, 15))
         {
             var id = match.Groups[1].Value.Trim();
             var name = CoreTools.FormatAsName(id);

--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs
@@ -263,7 +263,7 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
         }
 
         protected override IEnumerable<Package> GetInstalledPackages_UnSafe()
-            => TaskRecycler<IEnumerable<Package>>.RunOrAttachOrCache(_getInstalledPackages_UnSafe, 15);
+            => TaskRecycler<IEnumerable<Package>>.RunOrAttach(_getInstalledPackages_UnSafe, 15);
         private IEnumerable<Package> _getInstalledPackages_UnSafe()
         {
             List<Package> Packages = [];

--- a/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativeWinGetHelper.cs
+++ b/src/UniGetUI.PackageEngine.Managers.WinGet/WinGetHelpers/NativeWinGetHelper.cs
@@ -192,7 +192,7 @@ internal sealed class NativeWinGetHelper : IWinGetManagerHelper
     {
         var logger = Manager.TaskLogger.CreateNew(LoggableTaskType.ListInstalledPackages);
         List<Package> packages = [];
-        foreach (var nativePackage in TaskRecycler<IEnumerable<CatalogPackage>>.RunOrAttachOrCache(GetLocalWinGetPackages, 15))
+        foreach (var nativePackage in TaskRecycler<IEnumerable<CatalogPackage>>.RunOrAttach(GetLocalWinGetPackages, 15))
         {
             IManagerSource source;
             if (nativePackage.DefaultInstallVersion is not null)

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/BaseProviders/BaseSourceProvider.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Manager/BaseProviders/BaseSourceProvider.cs
@@ -41,7 +41,7 @@ namespace UniGetUI.PackageEngine.Classes.Manager.Providers
         protected abstract IEnumerable<IManagerSource> GetSources_UnSafe();
 
         public virtual IEnumerable<IManagerSource> GetSources()
-            => TaskRecycler<IEnumerable<IManagerSource>>.RunOrAttachOrCache(_getSources, 15);
+            => TaskRecycler<IEnumerable<IManagerSource>>.RunOrAttach(_getSources, 15);
 
         public virtual IEnumerable<IManagerSource> _getSources()
         {

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
@@ -164,7 +164,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
         {
             if (!IconHasBeenCached)
             {
-                CachedIcon = TaskRecycler<Uri?>.RunOrAttachOrCache(LoadIconUrlIfAny, 30);
+                CachedIcon = LoadIconUrlIfAny();
                 IconHasBeenCached = true;
             }
 
@@ -175,7 +175,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
         {
             try
             {
-                CacheableIcon? icon = Manager.GetPackageIconUrl(this);
+                CacheableIcon? icon = TaskRecycler<CacheableIcon?>.RunOrAttach(Manager.GetPackageIconUrl, this);
                 string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, Manager.Name, Id);
                 return path is null? null: new Uri("file:///" + path);
             }

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
@@ -176,7 +176,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
             try
             {
                 CacheableIcon? icon = Manager.GetPackageIconUrl(this);
-                string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, Manager.Name, Id).GetAwaiter().GetResult();
+                string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, Manager.Name, Id);
                 return path is null? null: new Uri("file:///" + path);
             }
             catch (Exception ex)

--- a/src/UniGetUI/Pages/SettingsPage.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPage.xaml.cs
@@ -31,6 +31,7 @@ namespace UniGetUI.Interface
         private readonly HyperlinkButton ResetBackupDirectory;
         private readonly HyperlinkButton OpenBackupDirectory;
         private readonly TextBlock BackupDirectoryLabel;
+        private bool InterfaceLoaded = false;
 
         public SettingsInterface()
         {
@@ -89,7 +90,7 @@ namespace UniGetUI.Interface
             ThemeSelector.ShowAddedItems();
 
             // UI Section
-            DisableIconsOnPackageLists.Text = "[EXPERIMENTAL] " + CoreTools.Translate("Show package icons on package lists");
+            // DisableIconsOnPackageLists.Text = "[EXPERIMENTAL] " + CoreTools.Translate("Show package icons on package lists");
 
 
             // Backup Section
@@ -333,6 +334,7 @@ namespace UniGetUI.Interface
                 EnableOrDisableEntries();
 
                 MainLayout.Children.Add(ManagerExpander);
+                InterfaceLoaded = true;
 
                 LoadIconCacheSize();
             }
@@ -424,12 +426,12 @@ namespace UniGetUI.Interface
 
         private void LanguageSelector_ValueChanged(object sender, EventArgs e)
         {
-            GeneralSettingsExpander.ShowRestartRequiredBanner();
+            if(InterfaceLoaded) GeneralSettingsExpander.ShowRestartRequiredBanner();
         }
 
         private void UpdatesCheckIntervalSelector_ValueChanged(object sender, EventArgs e)
         {
-            GeneralSettingsExpander.ShowRestartRequiredBanner();
+            if(InterfaceLoaded) GeneralSettingsExpander.ShowRestartRequiredBanner();
         }
 
         private void ThemeSelector_ValueChanged(object sender, EventArgs e)
@@ -482,19 +484,14 @@ namespace UniGetUI.Interface
             _ = CoreTools.ResetUACForCurrentProcess();
         }
 
-        private void UseSystemGSudo_StateChanged(object sender, EventArgs e)
-        {
-            AdminSettingsExpander.ShowRestartRequiredBanner();
-        }
-
         private void DisableWidgetsApi_StateChanged(object sender, EventArgs e)
-        { ExperimentalSettingsExpander.ShowRestartRequiredBanner(); }
+        { if(InterfaceLoaded) ExperimentalSettingsExpander.ShowRestartRequiredBanner(); }
 
         private void DisableDownloadingNewTranslations_StateChanged(object sender, EventArgs e)
-        { ExperimentalSettingsExpander.ShowRestartRequiredBanner(); }
+        { if(InterfaceLoaded) ExperimentalSettingsExpander.ShowRestartRequiredBanner(); }
 
         private void TextboxCard_ValueChanged(object sender, EventArgs e)
-        { ExperimentalSettingsExpander.ShowRestartRequiredBanner(); }
+        { if(InterfaceLoaded) ExperimentalSettingsExpander.ShowRestartRequiredBanner(); }
 
         private async void DoBackup_Click(object sender, EventArgs e)
         {
@@ -528,7 +525,7 @@ namespace UniGetUI.Interface
 
         private void EnablePackageBackupCheckBox_StateChanged(object sender, EventArgs e)
         {
-            EnablePackageBackupUI(EnablePackageBackupCheckBox.Checked);
+            if(InterfaceLoaded) EnablePackageBackupUI(EnablePackageBackupCheckBox.Checked);
         }
 
         public void EnablePackageBackupUI(bool enabled)
@@ -560,7 +557,8 @@ namespace UniGetUI.Interface
 
         private void UseUserGSudoToggle_StateChanged(object sender, EventArgs e)
         {
-            ExperimentalSettingsExpander.ShowRestartRequiredBanner();
+            if(InterfaceLoaded)
+                ExperimentalSettingsExpander.ShowRestartRequiredBanner();
         }
 
         private void ResetIconCache_OnClick(object? sender, EventArgs e)
@@ -581,7 +579,8 @@ namespace UniGetUI.Interface
 
         private void DisableIconsOnPackageLists_OnStateChanged(object? sender, EventArgs e)
         {
-            InterfaceSettingsExpander.ShowRestartRequiredBanner();
+            if(InterfaceLoaded)
+                InterfaceSettingsExpander.ShowRestartRequiredBanner();
         }
     }
 }


### PR DESCRIPTION
Improvements to how the icon cache works
 - Improve mimetype detection for URLs without extension filename
   - This fixes `.ico` files not rendering on Widgets for UniGetUI
   - This allows other-than-png files to be added to the icons and screenshots database
   - This eases handling of different image formats
 

 - Improvements to the TaskRecycler
   - Fix a race condition that would result with a second task being created when another one was already running but hadn't been added to the dictionary


 - Resize icons for a smaller impact on disk
   - Certain icon formats and sources will be downsized to 256x256