### PR TITLE
Add Setting for Default Startup Page

### DIFF
--- a/src/UniGetUI/MainWindow.xaml.cs
+++ b/src/UniGetUI/MainWindow.xaml.cs
@@ -399,16 +399,12 @@ namespace UniGetUI.Interface
             TrayIcon = new TaskbarIcon();
             ContentRoot.Children.Add(TrayIcon);
             Closed += (_, _) => TrayIcon.Dispose();
-            TrayIcon.ContextMenuMode = H.NotifyIcon.ContextMenuMode.PopupMenu;
+            TrayIcon.ContextMenuMode = ContextMenuMode.PopupMenu;
 
             XamlUICommand ShowHideCommand = new();
             ShowHideCommand.ExecuteRequested += (_, _) =>
             {
-                if (MainApp.Instance.TooltipStatus.AvailableUpdates > 0)
-                {
-                    MainApp.Instance?.MainWindow?.NavigationPage?.UpdatesNavButton?.ForceClick();
-                }
-
+                NavigationPage?.LoadDefaultPage();
                 Activate();
             };
 

--- a/src/UniGetUI/Pages/MainView.xaml.cs
+++ b/src/UniGetUI/Pages/MainView.xaml.cs
@@ -55,29 +55,7 @@ namespace UniGetUI.Interface
             PageButtonReference.Add(SettingsPage, SettingsNavButton);
             PageButtonReference.Add(BundlesPage, BundlesNavButton);
 
-            DiscoverNavButton.ForceClick();
-
-            string StartupPage = Settings.GetValue("StartupPage");
-            switch (StartupPage)
-            {
-                case "discover":
-                    NavigateToPage(DiscoverPage);
-                    break;
-                case "updates":
-                    NavigateToPage(UpdatesPage);
-                    break;
-                case "installed":
-                    NavigateToPage(InstalledPage);
-                    break;
-                case "bundles":
-                    NavigateToPage(BundlesPage);
-                    break;
-                case "settings":
-                    NavigateToPage(SettingsPage);
-                    break;
-                default: // setting not set or setting set to `default` (
-                    break;
-            }
+            LoadDefaultPage();
 
             if (CoreTools.IsAdministrator() && !Settings.Get("AlreadyWarnedAboutAdmin"))
             {
@@ -159,25 +137,45 @@ namespace UniGetUI.Interface
             };
         }
 
-        private void DiscoverNavButton_Click(object sender, EventArgs e)
+        public void LoadDefaultPage()
         {
-            NavigateToPage(DiscoverPage);
+            switch (Settings.GetValue("StartupPage"))
+            {
+                case "discover":
+                    NavigateToPage(DiscoverPage);
+                    break;
+                case "updates":
+                    NavigateToPage(UpdatesPage);
+                    break;
+                case "installed":
+                    NavigateToPage(InstalledPage);
+                    break;
+                case "bundles":
+                    NavigateToPage(BundlesPage);
+                    break;
+                case "settings":
+                    NavigateToPage(SettingsPage);
+                    break;
+                default:
+                    if (MainApp.Instance.TooltipStatus.AvailableUpdates > 0)
+                        NavigateToPage(UpdatesPage);
+                    else
+                        NavigateToPage(DiscoverPage);
+                    break;
+            }
         }
+
+        private void DiscoverNavButton_Click(object sender, EventArgs e)
+            => NavigateToPage(DiscoverPage);
 
         private void InstalledNavButton_Click(object sender, EventArgs e)
-        {
-            NavigateToPage(InstalledPage);
-        }
+            => NavigateToPage(InstalledPage);
 
         private void UpdatesNavButton_Click(object sender, EventArgs e)
-        {
-            NavigateToPage(UpdatesPage);
-        }
+            => NavigateToPage(UpdatesPage);
 
         private void BundlesNavButton_Click(object sender, EventArgs e)
-        {
-            NavigateToPage(BundlesPage);
-        }
+            => NavigateToPage(BundlesPage);
 
         private void MoreNavButton_Click(object sender, EventArgs e)
         {
@@ -202,9 +200,7 @@ namespace UniGetUI.Interface
         }
 
         private void SettingsNavButton_Click(object sender, EventArgs e)
-        {
-            NavigateToPage(SettingsPage);
-        }
+            => NavigateToPage(SettingsPage);
 
         private async void AboutNavButton_Click(object sender, EventArgs e)
         {
@@ -251,9 +247,7 @@ namespace UniGetUI.Interface
         }
 
         private void ReleaseNotesMenu_Click(object sender, RoutedEventArgs e)
-        {
-            DialogHelper.ShowReleaseNotes();
-        }
+            => DialogHelper.ShowReleaseNotes();
 
         private void OperationHistoryMenu_Click(object sender, RoutedEventArgs e)
         {
@@ -274,15 +268,9 @@ namespace UniGetUI.Interface
         {
             ShowHelp();
         }
-        public void ShowHelp()
-        {
-            if (HelpPage is null)
-            {
-                HelpPage = new HelpDialog();
-            }
 
-            NavigateToPage(HelpPage);
-        }
+        public void ShowHelp()
+            => NavigateToPage(HelpPage ??= new HelpDialog());
 
         private void QuitUniGetUI_Click(object sender, RoutedEventArgs e)
         {

--- a/src/UniGetUI/Pages/MainView.xaml.cs
+++ b/src/UniGetUI/Pages/MainView.xaml.cs
@@ -220,6 +220,8 @@ namespace UniGetUI.Interface
 
         private void NavigateToPage(Page TargetPage)
         {
+            if (CurrentPage == TargetPage) return;
+
             if (!PageButtonReference.TryGetValue(TargetPage, out var pageButton))
             {
                 PageButtonReference.Add(TargetPage, MoreNavButton);
@@ -229,7 +231,6 @@ namespace UniGetUI.Interface
             }
             foreach (NavButton button in MainApp.Instance.MainWindow.NavButtonList)
             {
-
                 button.ToggleButton.IsChecked = button == pageButton;
             }
 

--- a/src/UniGetUI/Pages/MainView.xaml.cs
+++ b/src/UniGetUI/Pages/MainView.xaml.cs
@@ -57,6 +57,28 @@ namespace UniGetUI.Interface
 
             DiscoverNavButton.ForceClick();
 
+            string StartupPage = Settings.GetValue("StartupPage");
+            switch (StartupPage)
+            {
+                case "discover":
+                    NavigateToPage(DiscoverPage);
+                    break;
+                case "updates":
+                    NavigateToPage(UpdatesPage);
+                    break;
+                case "installed":
+                    NavigateToPage(InstalledPage);
+                    break;
+                case "bundles":
+                    NavigateToPage(BundlesPage);
+                    break;
+                case "settings":
+                    NavigateToPage(SettingsPage);
+                    break;
+                default: // setting not set or setting set to `default` (
+                    break;
+            }
+
             if (CoreTools.IsAdministrator() && !Settings.Get("AlreadyWarnedAboutAdmin"))
             {
                 Settings.Set("AlreadyWarnedAboutAdmin", true);

--- a/src/UniGetUI/Pages/SettingsPage.xaml
+++ b/src/UniGetUI/Pages/SettingsPage.xaml
@@ -110,6 +110,11 @@
                                 SettingName="PreferredTheme"
                                 ValueChanged="ThemeSelector_ValueChanged"
                                 />
+                            <widgets:ComboboxCard
+                                x:Name="StartupPage"
+                                Text="Startup page:"
+                                SettingName="StartupPage"
+                                />
                             <widgets:CheckboxCard
                                 Text="Do not remove successful operations from the list automatically"
                                 SettingName="MaintainSuccessfulInstalls"

--- a/src/UniGetUI/Pages/SettingsPage.xaml
+++ b/src/UniGetUI/Pages/SettingsPage.xaml
@@ -112,12 +112,8 @@
                                 />
                             <widgets:ComboboxCard
                                 x:Name="StartupPageSelector"
-                                Text="Startup page:"
+                                Text="UniGetUI startup page:"
                                 SettingName="StartupPage"
-                                />
-                            <widgets:CheckboxCard
-                                Text="Do not remove successful operations from the list automatically"
-                                SettingName="MaintainSuccessfulInstalls"
                                 />
                             <widgets:CheckboxCard
                                 Text="Show UniGetUI on the system tray"
@@ -137,6 +133,10 @@
                                 x:Name="ResetIconCache"
                                 Click="ResetIconCache_OnClick"
                             />
+                            <widgets:CheckboxCard
+                                Text="Do not remove successful operations from the list automatically"
+                                SettingName="MaintainSuccessfulInstalls"
+                                />
                         </Toolkit:SettingsExpander.Items>
                     </widgets:SettingsEntry>
 

--- a/src/UniGetUI/Pages/SettingsPage.xaml
+++ b/src/UniGetUI/Pages/SettingsPage.xaml
@@ -111,7 +111,7 @@
                                 ValueChanged="ThemeSelector_ValueChanged"
                                 />
                             <widgets:ComboboxCard
-                                x:Name="StartupPage"
+                                x:Name="StartupPageSelector"
                                 Text="Startup page:"
                                 SettingName="StartupPage"
                                 />

--- a/src/UniGetUI/Pages/SettingsPage.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPage.xaml.cs
@@ -89,6 +89,15 @@ namespace UniGetUI.Interface
             ThemeSelector.AddItem(CoreTools.AutoTranslated("Follow system color scheme"), "auto");
             ThemeSelector.ShowAddedItems();
 
+            StartupPage.AddItem(CoreTools.AutoTranslated("Discover Packages"), "discover");
+            StartupPage.AddItem(CoreTools.AutoTranslated("Software Updates"), "updates");
+            StartupPage.AddItem(CoreTools.AutoTranslated("Installed Packages"), "installed");
+            StartupPage.AddItem(CoreTools.AutoTranslated("Package Bundles"), "bundles");
+            StartupPage.AddItem(CoreTools.AutoTranslated("Settings"), "settings");
+			// At the moment this is just discover (`DiscoverNavButton.ForceClick();` in MainView.xaml.cs), but that might change
+            StartupPage.AddItem(CoreTools.AutoTranslated("Default"), "default");
+            StartupPage.ShowAddedItems();
+
             // UI Section
             // DisableIconsOnPackageLists.Text = "[EXPERIMENTAL] " + CoreTools.Translate("Show package icons on package lists");
 

--- a/src/UniGetUI/Pages/SettingsPage.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPage.xaml.cs
@@ -31,7 +31,7 @@ namespace UniGetUI.Interface
         private readonly HyperlinkButton ResetBackupDirectory;
         private readonly HyperlinkButton OpenBackupDirectory;
         private readonly TextBlock BackupDirectoryLabel;
-        private bool InterfaceLoaded = false;
+        private bool InterfaceLoaded;
 
         public SettingsInterface()
         {
@@ -51,7 +51,7 @@ namespace UniGetUI.Interface
             bool isFirst = true;
             foreach (KeyValuePair<string, string> entry in lang_dict)
             {
-                LanguageSelector.AddItem(entry.Value, entry.Key.ToString(), isFirst);
+                LanguageSelector.AddItem(entry.Value, entry.Key, isFirst);
                 isFirst = false;
             }
             LanguageSelector.ShowAddedItems();
@@ -89,18 +89,13 @@ namespace UniGetUI.Interface
             ThemeSelector.AddItem(CoreTools.AutoTranslated("Follow system color scheme"), "auto");
             ThemeSelector.ShowAddedItems();
 
-            StartupPage.AddItem(CoreTools.AutoTranslated("Discover Packages"), "discover");
-            StartupPage.AddItem(CoreTools.AutoTranslated("Software Updates"), "updates");
-            StartupPage.AddItem(CoreTools.AutoTranslated("Installed Packages"), "installed");
-            StartupPage.AddItem(CoreTools.AutoTranslated("Package Bundles"), "bundles");
-            StartupPage.AddItem(CoreTools.AutoTranslated("Settings"), "settings");
-			// At the moment this is just discover (`DiscoverNavButton.ForceClick();` in MainView.xaml.cs), but that might change
-            StartupPage.AddItem(CoreTools.AutoTranslated("Default"), "default");
-            StartupPage.ShowAddedItems();
-
-            // UI Section
-            // DisableIconsOnPackageLists.Text = "[EXPERIMENTAL] " + CoreTools.Translate("Show package icons on package lists");
-
+            StartupPageSelector.AddItem(CoreTools.AutoTranslated("Default"), "default");
+            StartupPageSelector.AddItem(CoreTools.AutoTranslated("Discover Packages"), "discover");
+            StartupPageSelector.AddItem(CoreTools.AutoTranslated("Software Updates"), "updates");
+            StartupPageSelector.AddItem(CoreTools.AutoTranslated("Installed Packages"), "installed");
+            StartupPageSelector.AddItem(CoreTools.AutoTranslated("Package Bundles"), "bundles");
+            StartupPageSelector.AddItem(CoreTools.AutoTranslated("Settings"), "settings");
+            StartupPageSelector.ShowAddedItems();
 
             // Backup Section
             BackupDirectoryLabel = (TextBlock)((StackPanel)ChangeBackupDirectory.Description).Children.ElementAt(0);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

This pull request adds a setting to change the default startup page that UniGetUI opens to.

-----
<!-- insert below the issue number (if applicable, do not create a new issue to justify a PR) -->
Closes #2733
