### PR TITLE
Improve CoreTools.FormatAsName For Multi-Word vcpkg Options

### DIFF
--- a/src/UniGetUI.Core.Tools.Tests/ToolsTests.cs
+++ b/src/UniGetUI.Core.Tools.Tests/ToolsTests.cs
@@ -59,8 +59,8 @@ namespace UniGetUI.Core.Tools.Tests
         [InlineData("!helloWorld", "!helloWorld")]
         [InlineData("@stylistic/eslint-plugin", "Eslint Plugin")]
         [InlineData("Flask-RESTful", "Flask RESTful")]
-        [InlineData("vcpkg-item[option]", "Vcpkg Item[Option]")]
-        [InlineData("vcpkg-item[multi-option]", "Vcpkg Item[Multi Option]")]
+        [InlineData("vcpkg-item[option]", "Vcpkg Item [Option]")]
+        [InlineData("vcpkg-item[multi-option]", "Vcpkg Item [Multi Option]")]
         public void TestFormatAsName(string id, string name)
         {
             Assert.Equal(name, CoreTools.FormatAsName(id));

--- a/src/UniGetUI.Core.Tools.Tests/ToolsTests.cs
+++ b/src/UniGetUI.Core.Tools.Tests/ToolsTests.cs
@@ -59,6 +59,8 @@ namespace UniGetUI.Core.Tools.Tests
         [InlineData("!helloWorld", "!helloWorld")]
         [InlineData("@stylistic/eslint-plugin", "Eslint Plugin")]
         [InlineData("Flask-RESTful", "Flask RESTful")]
+        [InlineData("vcpkg-item[option]", "Vcpkg Item[Option]")]
+        [InlineData("vcpkg-item[multi-option]", "Vcpkg Item[Multi Option]")]
         public void TestFormatAsName(string id, string name)
         {
             Assert.Equal(name, CoreTools.FormatAsName(id));

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -153,6 +153,7 @@ namespace UniGetUI.Core.Tools
                     newName += name[i];
                 }
             }
+            newName = newName.Replace(" [", "[").Replace("[", " [");
             return newName;
         }
 

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -108,8 +108,6 @@ namespace UniGetUI.Core.Tools
 
             try
             {
-
-
                 process.Start();
                 string? line = process.StandardOutput.ReadLine();
                 string output;
@@ -146,7 +144,7 @@ namespace UniGetUI.Core.Tools
             string newName = "";
             for (int i = 0; i < name.Length; i++)
             {
-                if (i == 0 || name[i - 1] == ' ')
+                if (i == 0 || name[i - 1] == ' ' || name[i - 1] == '[' /* for vcpkg options */)
                 {
                     newName += name[i].ToString().ToUpper();
                 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

This PR changes `CoreTools.FormatAsName` to format multi-word vcpkg options consistently.
Before this PR, vcpkg options with multiple words would have their first word lowercase, and the following words uppercase, but this is inconsistent and looks odd.
![image](https://github.com/user-attachments/assets/e03aace7-2530-4628-b984-7617f50393d8)