### PR TITLE
Add a "Cancel All Operations" Button

### DIFF
--- a/src/UniGetUI/Pages/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/SoftwareUpdatesPage.cs
@@ -202,6 +202,7 @@ namespace UniGetUI.Interface.SoftwarePages
             AppBarButton HelpButton = new();
 
             ToolBar.PrimaryCommands.Add(CancelAllOperations);
+            ToolBar.PrimaryCommands.Add(new AppBarSeparator());
             ToolBar.PrimaryCommands.Add(UpdateSelected);
             ToolBar.PrimaryCommands.Add(UpdateAsAdmin);
             ToolBar.PrimaryCommands.Add(UpdateSkipHash);

--- a/src/UniGetUI/Pages/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/SoftwareUpdatesPage.cs
@@ -23,6 +23,7 @@ namespace UniGetUI.Interface.SoftwarePages
         private BetterMenuItem? MenuInteractive;
         private BetterMenuItem? MenuskipHash;
         private BetterMenuItem? MenuOpenInstallLocation;
+        private AppBarButton CancelAllOperations;
 
         private int LastNotificationUpdateCount = -1;
 
@@ -184,6 +185,7 @@ namespace UniGetUI.Interface.SoftwarePages
 
         public override void GenerateToolBar()
         {
+            CancelAllOperations = new();
             AppBarButton UpdateSelected = new();
             AppBarButton UpdateAsAdmin = new();
             AppBarButton UpdateSkipHash = new();
@@ -199,6 +201,7 @@ namespace UniGetUI.Interface.SoftwarePages
 
             AppBarButton HelpButton = new();
 
+            ToolBar.PrimaryCommands.Add(CancelAllOperations);
             ToolBar.PrimaryCommands.Add(UpdateSelected);
             ToolBar.PrimaryCommands.Add(UpdateAsAdmin);
             ToolBar.PrimaryCommands.Add(UpdateSkipHash);
@@ -217,6 +220,7 @@ namespace UniGetUI.Interface.SoftwarePages
             Dictionary<AppBarButton, string> Labels = new()
             { // Entries with a trailing space are collapsed
               // Their texts will be used as the tooltip
+                { CancelAllOperations,  CoreTools.Translate("Cancel All Operations") },
                 { UpdateSelected,       CoreTools.Translate("Update selected packages") },
                 { UpdateAsAdmin,        " " + CoreTools.Translate("Update as administrator") },
                 { UpdateSkipHash,       " " + CoreTools.Translate("Skip integrity checks") },
@@ -242,6 +246,7 @@ namespace UniGetUI.Interface.SoftwarePages
 
             Dictionary<AppBarButton, IconType> Icons = new()
             {
+                { CancelAllOperations,  IconType.Cross },
                 { UpdateSelected,       IconType.Update },
                 { UpdateAsAdmin,        IconType.UAC },
                 { UpdateSkipHash,       IconType.Checksum },
@@ -309,6 +314,15 @@ namespace UniGetUI.Interface.SoftwarePages
             };
 
             SharePackage.Click += (_, _) => MainApp.Instance.MainWindow.SharePackage(SelectedItem);
+
+            CancelAllOperations.Click += (_, _) =>
+            {
+                foreach (AbstractOperation operation in MainApp.Instance.MainWindow.NavigationPage.OperationStackPanel.Children)
+                {
+                    operation.CancelButtonClicked();
+                }
+                MainApp.Instance.MainWindow.NavigationPage.OperationStackPanel.Children.Clear();
+            };
         }
 
         protected override void WhenPackageCountUpdated()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

As the title says; adds a button to the updates page toolbar to cancel all operations.

-----
<!-- insert below the issue number (if applicable, do not create a new issue to justify a PR) -->
Closes #1474 
