### PR TITLE
Fix the vcpkg (normalized) icon ID

### DIFF
--- a/src/UniGetUI.PackageEngine.Package/Package.cs
+++ b/src/UniGetUI.PackageEngine.Package/Package.cs
@@ -197,6 +197,8 @@ namespace UniGetUI.PackageEngine.PackageClasses
                 iconId = iconId.Replace(".install", "").Replace(".portable", "");
             else if (Manager.Name == "Scoop")
                 iconId = iconId.Replace(".app", "");
+            else if (Manager.Name == "vcpkg")
+                iconId = iconId.split(":")[0].Split("[")[0];
             return iconId;
         }
 

--- a/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
+++ b/src/UniGetUI.PackageEngine.PackageManagerClasses/Packages/Package.cs
@@ -103,6 +103,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
                 "Winget" => string.Join('.', id.ToLower().Split(".")[1..]),
                 "Scoop" => id.ToLower().Replace(".app", ""),
                 "Chocolatey" => id.ToLower().Replace(".install", "").Replace(".portable", ""),
+                "vcpkg" => id.ToLower().Split(":")[0].Split("[")[0],
                 _ => id.ToLower()
             };
         }
@@ -173,7 +174,7 @@ namespace UniGetUI.PackageEngine.PackageClasses
             try
             {
                 CacheableIcon? icon = TaskRecycler<CacheableIcon?>.RunOrAttach(Manager.DetailsHelper.GetIcon, this);
-                string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, Manager.Name, Id);
+                string? path = IconCacheEngine.GetCacheOrDownloadIcon(icon, Manager.Name, _iconId);
                 return path is null? null: new Uri("file:///" + path);
             }
             catch (Exception ex)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

Winget package IDs are normalized to remove the publisher; this pull request does the same thing to vcpkg packages, removing the triplet so they can take advantage of the icons in the screenshot database. It also makes it so the `AbstractPackagesPage` icons take into account this normalization, which it doesn't seem as if it was doing before.