### PR TITLE
Updated Winget Workflows to Newer Versions

### DIFF
--- a/.github/workflows/winget-prerelease.yml
+++ b/.github/workflows/winget-prerelease.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Publish to WinGet
-        uses: vedantmgoyal2009/winget-releaser@main
+        uses: vedantmgoyal2009/winget-releaser@a3ac67b0c3026bc335a33b722188e3ec769d6a64
         with:
           identifier: MartiCliment.UniGetUI.Pre-Release
           installers-regex: 'UniGetUI\.Installer\.exe$'

--- a/.github/workflows/winget-prerelease.yml
+++ b/.github/workflows/winget-prerelease.yml
@@ -12,8 +12,9 @@ jobs:
 
     steps:
       - name: Publish to WinGet
-        uses: vedantmgoyal2009/winget-releaser@v2
+        uses: vedantmgoyal2009/winget-releaser@main
         with:
           identifier: MartiCliment.UniGetUI.Pre-Release
+          installers-regex: 'UniGetUI\.Installer\.exe$'
           version: ${{ github.event.release.tag_name }}
           token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget-stable.yml
+++ b/.github/workflows/winget-stable.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@main
+      - uses: vedantmgoyal2009/winget-releaser@a3ac67b0c3026bc335a33b722188e3ec769d6a64
         with:
           identifier: MartiCliment.UniGetUI
           installers-regex: 'UniGetUI\.Installer\.exe$'

--- a/.github/workflows/winget-stable.yml
+++ b/.github/workflows/winget-stable.yml
@@ -8,8 +8,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal2009/winget-releaser@main
         with:
           identifier: MartiCliment.UniGetUI
+          installers-regex: 'UniGetUI\.Installer\.exe$'
           version: ${{ github.event.release.tag_name }}
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

This update enhances the WinGet release workflow to ensure it processes only the specific installer file, `UniGetUI.Installer.exe`. It also ensures to use the latest version of the `winget-releaser` since the old v2 release still uses the old Manifest Version 1.5.0, which is not encouraged anymore due to it now being on version 1.9.0; this is happening due to the v2 version of 'winget-releaser` using Komac version 1.11.0, currently we are on Komac version 2.8.0.

I think new releases will not happen for `winget-releaser` since the whole codebase seems to have changed from v2 to now and it is now using mostly CLI commands, so I think this is the way forward.

-----

