### PR TITLE
Reorder max operation logs

### DIFF
--- a/src/UniGetUI.PackageEngine.Operations/AbstractOperation.cs
+++ b/src/UniGetUI.PackageEngine.Operations/AbstractOperation.cs
@@ -125,13 +125,13 @@ public abstract class AbstractOperation : IDisposable
 
         if(int.TryParse(Settings.GetValue("ParallelOperationCount"), out int _maxPps))
         {
-            Logger.Debug("Parallel operation limit not set, defaulting to 1");
-            MAX_OPERATIONS = _maxPps;
+            MAX_OPERATIONS = _maxPps; 
+            Logger.Debug($"Parallel operation limit set to {MAX_OPERATIONS}");
         }
         else
         {
             MAX_OPERATIONS = 1;
-            Logger.Debug($"Parallel operation limit set to {MAX_OPERATIONS}");
+            Logger.Debug("Parallel operation limit not set, defaulting to 1");
         }
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

Reorder incorrect / confusing log messages
