### PR TITLE
Fix WinGet getting corrupted on devices with non-admin accounts

### DIFF
--- a/src/UniGetUI.Core.Data/CoreData.cs
+++ b/src/UniGetUI.Core.Data/CoreData.cs
@@ -173,7 +173,7 @@ namespace UniGetUI.Core.Data
             }
         }
 
-        public static string GSudoPath = "";
+        public static string ElevatorPath = "";
 
         /// <summary>
         /// This method will return the most appropriate data directory.

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -420,7 +420,7 @@ Crash Traceback:
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = CoreData.GSudoPath,
+                    FileName = CoreData.ElevatorPath,
                     Arguments = "cache on --pid " + Environment.ProcessId + " -d 1",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
@@ -444,7 +444,7 @@ Crash Traceback:
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = CoreData.GSudoPath,
+                    FileName = CoreData.ElevatorPath,
                     Arguments = "cache off --pid " + Environment.ProcessId,
                     UseShellExecute = false,
                     RedirectStandardOutput = true,

--- a/src/UniGetUI.Core.Tools/Tools.cs
+++ b/src/UniGetUI.Core.Tools/Tools.cs
@@ -10,6 +10,7 @@ using UniGetUI.Core.Classes;
 using UniGetUI.Core.Data;
 using UniGetUI.Core.Language;
 using UniGetUI.Core.Logging;
+using UniGetUI.Core.SettingsEngine;
 
 namespace UniGetUI.Core.Tools
 {
@@ -558,9 +559,10 @@ Crash Traceback:
 
         public static async Task _waitForInternetConnection()
         {
-            Logger.Debug(
-                "Checking for internet connectivity. Pinging google.com, microsoft.com, couldflare.com and marticliment.com");
-            string[] hosts = ["google.com", "microsoft.com", "cloudflare.com", "marticliment.com"];
+            if (Settings.Get("DisableWaitForInternetConnection")) return;
+
+            Logger.Debug("Checking for internet connectivity. Pinging google.com, microsoft.com, couldflare.com and marticliment.com");
+            string[] hosts = ["google.com", "microsoft.com", "cloudflare.com", "github.com"];
             while (true)
             {
                 foreach (var host in hosts)

--- a/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/PackageOperations.cs
@@ -9,6 +9,7 @@ using UniGetUI.Interface.Enums;
 using UniGetUI.PackageEngine.Classes.Packages.Classes;
 using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
+using UniGetUI.PackageEngine.Managers.WingetManager;
 using UniGetUI.PackageEngine.PackageClasses;
 using UniGetUI.PackageEngine.PackageLoader;
 using UniGetUI.PackageOperations;
@@ -59,7 +60,7 @@ namespace UniGetUI.PackageEngine.Operations
         {
             return Package.OverridenOptions.RunAsAdministrator is true
                     || Options.RunAsAdministrator
-                    || (Settings.Get("AlwaysElevate" + Package.Manager.Name) && !Package.OverridenOptions.RunAsAdministrator is false);
+                    || (Settings.Get("AlwaysElevate" + Package.Manager.Name) && Package.OverridenOptions.RunAsAdministrator != false);
         }
 
         protected override void ApplyRetryAction(string retryMode)
@@ -98,19 +99,27 @@ namespace UniGetUI.PackageEngine.Operations
                     CoreTools.CacheUACForCurrentProcess().GetAwaiter().GetResult();
                 }
 
-                process.StartInfo.FileName = CoreData.GSudoPath;
-                process.StartInfo.Arguments =
-                    $"\"{Package.Manager.Status.ExecutablePath}\" {Package.Manager.Properties.ExecutableCallArgs} {operation_args}";
+                if (Package.Manager is WinGet)
+                {
+                    string WinGetTemp = Path.Join(Path.GetTempPath(), "UniGetUI", "ElevatedWinGetTemp");
+                    process.StartInfo.Environment["TEMP"] = WinGetTemp;
+                    process.StartInfo.Environment["TMP"] = WinGetTemp;
+                }
+                process.StartInfo.FileName = CoreData.ElevatorPath;
+                process.StartInfo.Arguments = $"\"{Package.Manager.Status.ExecutablePath}\" {Package.Manager.Properties.ExecutableCallArgs} {operation_args}";
             }
             else
             {
                 process.StartInfo.FileName = Package.Manager.Status.ExecutablePath;
                 process.StartInfo.Arguments = $"{Package.Manager.Properties.ExecutableCallArgs} {operation_args}";
             }
-            ApplyCapabilities(admin,
+
+            ApplyCapabilities(
+                admin,
                 Options.InteractiveInstallation,
                 (Options.SkipHashCheck && Role is not OperationType.Uninstall),
-                Package.OverridenOptions.Scope ?? Options.InstallationScope);
+                Package.OverridenOptions.Scope ?? Options.InstallationScope
+            );
         }
 
         protected sealed override Task<OperationVeredict> GetProcessVeredict(int ReturnCode, string[] Output)

--- a/src/UniGetUI.PackageEngine.Operations/SourceOperations.cs
+++ b/src/UniGetUI.PackageEngine.Operations/SourceOperations.cs
@@ -62,7 +62,7 @@ namespace UniGetUI.PackageEngine.Operations
                 }
 
                 admin = true;
-                process.StartInfo.FileName = CoreData.GSudoPath;
+                process.StartInfo.FileName = CoreData.ElevatorPath;
                 process.StartInfo.Arguments = $"\"{Source.Manager.Status.ExecutablePath}\" " + Source.Manager.Properties.ExecutableCallArgs + " " + string.Join(" ", Source.Manager.SourcesHelper.GetAddSourceParameters(Source));
             }
             else
@@ -108,7 +108,7 @@ namespace UniGetUI.PackageEngine.Operations
                 {
                     CoreTools.CacheUACForCurrentProcess().GetAwaiter().GetResult();
                 }
-                process.StartInfo.FileName = CoreData.GSudoPath;
+                process.StartInfo.FileName = CoreData.ElevatorPath;
                 process.StartInfo.Arguments = $"\"{Source.Manager.Status.ExecutablePath}\" " + Source.Manager.Properties.ExecutableCallArgs + " " + string.Join(" ", Source.Manager.SourcesHelper.GetRemoveSourceParameters(Source));
 
             }

--- a/src/UniGetUI.PackageEngine.PackageEngine/PEInterface.cs
+++ b/src/UniGetUI.PackageEngine.PackageEngine/PEInterface.cs
@@ -12,6 +12,7 @@ using UniGetUI.PackageEngine.Managers.WingetManager;
 using UniGetUI.PackageEngine.Managers.VcpkgManager;
 using UniGetUI.PackageEngine.PackageLoader;
 using System.Collections.ObjectModel;
+using UniGetUI.Core.Tools;
 using UniGetUI.PackageOperations;
 
 namespace UniGetUI.PackageEngine
@@ -64,8 +65,8 @@ namespace UniGetUI.PackageEngine
                 Logger.Warn("Timeout: Not all package managers have finished initializing.");
             }
 
-            _ = UpgradablePackagesLoader.ReloadPackages();
             _ = InstalledPackagesLoader.ReloadPackages();
+            _ = UpgradablePackagesLoader.ReloadPackages();
         }
     }
 }

--- a/src/UniGetUI.PackageEngine.PackageLoader/AbstractPackageLoader.cs
+++ b/src/UniGetUI.PackageEngine.PackageLoader/AbstractPackageLoader.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using UniGetUI.Core.Tools;
 using UniGetUI.PackageEngine.Interfaces;
 
 namespace UniGetUI.PackageEngine.PackageLoader
@@ -48,11 +49,18 @@ namespace UniGetUI.PackageEngine.PackageLoader
         private readonly bool ALLOW_MULTIPLE_PACKAGE_VERSIONS;
         private readonly bool DISABLE_RELOAD;
         private readonly bool PACKAGES_CHECKED_BY_DEFAULT;
+        private readonly bool REQUIRES_INTERNET;
         protected string LOADER_IDENTIFIER;
         private int LoadOperationIdentifier;
         protected IEnumerable<IPackageManager> Managers { get; private set; }
 
-        public AbstractPackageLoader(IEnumerable<IPackageManager> managers, string identifier, bool AllowMultiplePackageVersions = false, bool DisableReload = false, bool CheckedBydefault = false)
+        public AbstractPackageLoader(
+            IEnumerable<IPackageManager> managers,
+            string identifier,
+            bool AllowMultiplePackageVersions,
+            bool DisableReload,
+            bool CheckedBydefault,
+            bool RequiresInternet)
         {
             Managers = managers;
             PackageReference = new ConcurrentDictionary<long, IPackage>();
@@ -63,6 +71,7 @@ namespace UniGetUI.PackageEngine.PackageLoader
             ALLOW_MULTIPLE_PACKAGE_VERSIONS = AllowMultiplePackageVersions;
             LOADER_IDENTIFIER = identifier;
             ALLOW_MULTIPLE_PACKAGE_VERSIONS = AllowMultiplePackageVersions;
+            REQUIRES_INTERNET = RequiresInternet;
         }
 
         /// <summary>
@@ -107,6 +116,11 @@ namespace UniGetUI.PackageEngine.PackageLoader
             int current_identifier = LoadOperationIdentifier;
             IsLoading = true;
             StartedLoading?.Invoke(this, EventArgs.Empty);
+
+            if (REQUIRES_INTERNET)
+            {
+                await CoreTools.WaitForInternetConnection();
+            }
 
             List<Task<IEnumerable<IPackage>>> tasks = new();
 

--- a/src/UniGetUI.PackageEngine.PackageLoader/DiscoverablePackagesLoader.cs
+++ b/src/UniGetUI.PackageEngine.PackageLoader/DiscoverablePackagesLoader.cs
@@ -11,7 +11,12 @@ namespace UniGetUI.PackageEngine.PackageLoader
         private string QUERY_TEXT = string.Empty;
 
         public DiscoverablePackagesLoader(IEnumerable<IPackageManager> managers)
-            : base(managers, "DISCOVERABLE_PACKAGES", AllowMultiplePackageVersions: false, CheckedBydefault: false)
+            : base(managers,
+                identifier: "DISCOVERABLE_PACKAGES",
+                AllowMultiplePackageVersions: false,
+                DisableReload: false,
+                CheckedBydefault: false,
+                RequiresInternet: true)
         {
             Instance = this;
         }

--- a/src/UniGetUI.PackageEngine.PackageLoader/InstalledPackagesLoader.cs
+++ b/src/UniGetUI.PackageEngine.PackageLoader/InstalledPackagesLoader.cs
@@ -9,7 +9,13 @@ namespace UniGetUI.PackageEngine.PackageLoader
         public static InstalledPackagesLoader Instance = null!;
 
         public InstalledPackagesLoader(IEnumerable<IPackageManager> managers)
-        : base(managers, "INSTALLED_PACKAGES", AllowMultiplePackageVersions: true, CheckedBydefault: false)
+        : base(
+            managers,
+            identifier: "INSTALLED_PACKAGES",
+            AllowMultiplePackageVersions: true,
+            DisableReload: false,
+            CheckedBydefault: false,
+            RequiresInternet: true)
         {
             Instance = this;
         }

--- a/src/UniGetUI.PackageEngine.PackageLoader/PackageBundlesLoader.cs
+++ b/src/UniGetUI.PackageEngine.PackageLoader/PackageBundlesLoader.cs
@@ -10,7 +10,12 @@ namespace UniGetUI.PackageEngine.PackageLoader
         public static PackageBundlesLoader Instance = null!;
 
         public PackageBundlesLoader(IEnumerable<IPackageManager> managers)
-        : base(managers, "PACKAGE_BUNDLES", AllowMultiplePackageVersions: true, DisableReload: true, CheckedBydefault: false)
+        : base(managers,
+            identifier: "PACKAGE_BUNDLES",
+            AllowMultiplePackageVersions: true,
+            DisableReload: true,
+            CheckedBydefault: false,
+            RequiresInternet: false)
         {
             Instance = this;
         }

--- a/src/UniGetUI.PackageEngine.PackageLoader/UpgradablePackagesLoader.cs
+++ b/src/UniGetUI.PackageEngine.PackageLoader/UpgradablePackagesLoader.cs
@@ -18,7 +18,12 @@ namespace UniGetUI.PackageEngine.PackageLoader
         public ConcurrentDictionary<string, IPackage> IgnoredPackages = new();
 
         public UpgradablePackagesLoader(IEnumerable<IPackageManager> managers)
-        : base(managers, "DISCOVERABLE_PACKAGES", AllowMultiplePackageVersions: false, CheckedBydefault: !Settings.Get("DisableSelectingUpdatesByDefault"))
+        : base(managers,
+            identifier: "UPGRADABLE_PACKAGES",
+            AllowMultiplePackageVersions: false,
+            DisableReload: false,
+            CheckedBydefault: !Settings.Get("DisableSelectingUpdatesByDefault"),
+            RequiresInternet: true)
         {
             Instance = this;
             FinishedLoading += (_, _) => StartAutoCheckTimeout();

--- a/src/UniGetUI/App.xaml.cs
+++ b/src/UniGetUI/App.xaml.cs
@@ -118,7 +118,7 @@ namespace UniGetUI
             if (!DEBUG && !Settings.Get("DisableUniGetUIElevator"))
             {
                 Logger.ImportantInfo("Using built-in UniGetUI Elevator");
-                CoreData.GSudoPath = Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Utilities", "UniGetUI Elevator.exe");
+                CoreData.ElevatorPath = Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Utilities", "UniGetUI Elevator.exe");
             }
             else if (Settings.Get("UseUserGSudo"))
             {
@@ -126,18 +126,18 @@ namespace UniGetUI
                 if (found)
                 {
                     Logger.Info($"Using System GSudo at {gsudo_path}");
-                    CoreData.GSudoPath = gsudo_path;
+                    CoreData.ElevatorPath = gsudo_path;
                 }
                 else
                 {
                     Logger.Error("System GSudo enabled but not found!");
-                    CoreData.GSudoPath = Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Utilities", "gsudo.exe");
+                    CoreData.ElevatorPath = Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Utilities", "gsudo.exe");
                 }
             }
             else
             {
-                Logger.Warn($"Using bundled GSudo at {CoreData.GSudoPath} since UniGetUI Elevator is not available!");
-                CoreData.GSudoPath = Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Utilities", "gsudo.exe");
+                Logger.Warn($"Using bundled GSudo at {CoreData.ElevatorPath} since UniGetUI Elevator is not available!");
+                CoreData.ElevatorPath = Path.Join(CoreData.UniGetUIExecutableDirectory, "Assets", "Utilities", "gsudo.exe");
             }
         }
 

--- a/src/UniGetUI/Pages/SettingsPage.xaml
+++ b/src/UniGetUI/Pages/SettingsPage.xaml
@@ -361,6 +361,12 @@
                                 SettingName="DisableLangAutoUpdater"
                                 StateChanged="DisableDownloadingNewTranslations_StateChanged"
                                 />
+                            <widgets:CheckboxCard
+                                x:Name="DisableWaitForInternetConnection"
+                                Text="Wait for the device to be connected to the internet before attempting to do tasks that require internet connectivity."
+                                SettingName="DisableWaitForInternetConnection"
+                                StateChanged="DisableDownloadingNewTranslations_StateChanged"
+                            />
                             <widgets:TextboxCard
                                 Text="Use a custom icon and screenshot database URL"
                                 Placeholder="Leave empty for default"

--- a/test_publish.cmd
+++ b/test_publish.cmd
@@ -1,6 +1,6 @@
 @echo off
-rmdir /q /s src\UniGetUI\bin\x64\Release\net8.0-windows10.0.22621.0\win-x64\publish\
+rmdir /q /s src\UniGetUI\bin\x64\Release\net8.0-windows10.0.26100.0\win-x64\publish\
 dotnet publish src/UniGetUI/UniGetUI.csproj /noLogo /property:Configuration=Release /property:Platform=x64 -v m
-%signcommand% "src\UniGetUI\bin\x64\Release\net8.0-windows10.0.22621.0\win-x64\publish\UniGetUI.exe"
-src\UniGetUI\bin\x64\Release\net8.0-windows10.0.22621.0\win-x64\publish\UniGetUI.exe
+%signcommand% "src\UniGetUI\bin\x64\Release\net8.0-windows10.0.26100.0\win-x64\publish\UniGetUI.exe"
+src\UniGetUI\bin\x64\Release\net8.0-windows10.0.26100.0\win-x64\publish\UniGetUI.exe
 pause


### PR DESCRIPTION
 - Redirect WinGet temp folder when running elevated, so it does not change ACLs on `%temp%\WinGet`, and then it stops working due to incorrect permissions. This would only happen when UniGetUI was running from a local account, and different credentials of a different account were provided to Elevator/GSudo.

 - Wait for an internet connection before loading package lists. This condition also triggered the WinGet corruption banner.