### PR TITLE
Delay Auto-Update Until All Operations Have Completed

### DIFF
--- a/src/UniGetUI/AutoUpdater.cs
+++ b/src/UniGetUI/AutoUpdater.cs
@@ -9,6 +9,7 @@ using UniGetUI.Core.Data;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.Tools;
+using UniGetUI.Interface;
 using UniGetUI.Interface.Enums;
 
 namespace UniGetUI;
@@ -262,11 +263,12 @@ public class AutoUpdater
         }
         else
         {
-            Logger.Debug("Waiting for mainWindow to be closed or for user to trigger the update from the notification...");
+            Logger.Debug("Waiting for mainWindow to be closed, operations to complete, or for user to trigger the update from the notification...");
             while (
                 !ReleaseLockForAutoupdate_Window &&
                 !ReleaseLockForAutoupdate_Notification &&
-                !ReleaseLockForAutoupdate_UpdateBanner)
+                !ReleaseLockForAutoupdate_UpdateBanner &&
+                MainApp.Operations._operationList.Count == 0)
             {
                 await Task.Delay(100);
             }

--- a/src/UniGetUI/AutoUpdater.cs
+++ b/src/UniGetUI/AutoUpdater.cs
@@ -268,7 +268,7 @@ public class AutoUpdater
                 !ReleaseLockForAutoupdate_Window &&
                 !ReleaseLockForAutoupdate_Notification &&
                 !ReleaseLockForAutoupdate_UpdateBanner &&
-                MainApp.Operations._operationList.Count == 0)
+                MainApp.Operations.AreThereRunningOperations())
             {
                 await Task.Delay(100);
             }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

This PR has UniGetUI wait until all operations in the queue have finished before automatically updating.

-----
Closes #3277
