### PR TITLE
Use KeyDown instead of KeyUp to handle MainView keyboard shortcuts

### DIFF
--- a/src/UniGetUI/Pages/MainView.xaml.cs
+++ b/src/UniGetUI/Pages/MainView.xaml.cs
@@ -73,8 +73,14 @@ namespace UniGetUI.Interface
             }
 
             MoreNavButtonMenu.Closed += (_, _) => SelectNavButtonForPage(CurrentPage_t);
-            KeyUp += (s, e) =>
+            KeyDown += (s, e) =>
             {
+                if (e.KeyStatus.WasKeyDown)
+                {
+                    // ignore repeated KeyDown events when pressing and holding a key
+                    return;
+                }
+
                 bool IS_CONTROL_PRESSED = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
                 bool IS_SHIFT_PRESSED = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
 


### PR DESCRIPTION
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

Use `KeyDown` event for handling MainView keyboard shortcuts to prevent handling key presses initiated in other applications. Ignoring events with `KeyStatus.WasKeyDown == true` to ignore key down events resulting from holding down a key.

-----
Closes #3298