### PR TITLE
Always Update Indexes

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Vcpkg/Vcpkg.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Vcpkg/Vcpkg.cs
@@ -345,7 +345,7 @@ namespace UniGetUI.PackageEngine.Managers.VcpkgManager
             var (vcpkgRootFound, vcpkgRoot) = GetVcpkgRoot();
             var (gitFound, gitPath) = CoreTools.Which("git");
 
-            if (!found || !gitFound || !vcpkgRootFound || Settings.Get("DisableUpdateVcpkgGitPorts"))
+            if (!found || !gitFound || !vcpkgRootFound)
             {
                 INativeTaskLogger logger = TaskLogger.CreateNew(LoggableTaskType.RefreshIndexes);
                 if (Settings.Get("DisableUpdateVcpkgGitPorts")) logger.Error("User has disabled updating sources");

--- a/src/UniGetUI/Pages/SettingsPage.xaml.cs
+++ b/src/UniGetUI/Pages/SettingsPage.xaml.cs
@@ -245,14 +245,6 @@ namespace UniGetUI.Interface
 
                 // ----------------------------------------------------------------------------------------
 
-                CheckboxCard Vcpkg_UpdateGitPorts = new()
-                {
-                    Text = CoreTools.Translate(
-                        "Update vcpkg's Git portfiles automatically (requires Git installed)"),
-                    SettingName = "DisableUpdateVcpkgGitPorts"
-                };
-                ExtraSettingsCards[PEInterface.Vcpkg].Add(Vcpkg_UpdateGitPorts);
-
                 // GetDefaultTriplet factors in the `DefaultVcpkgTriplet` setting as its first priority
                 Settings.SetValue("DefaultVcpkgTriplet", Vcpkg.GetDefaultTriplet());
                 ComboboxCard Vcpkg_DefaultTriplet = new()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

In attempting to update `bzip2` before pressing "update now" to the new 3.1.7 update, the bzip update fails (not due to UniGetUI, but due to vcpkg that was _impacted_ by UniGetUI), and as microsoft/vcpkg#43297 suggests it's because a recent vcpkg commit changed the way the system works, however while commit 9e3482c307cb549692cf3938af7adf9f70c341db in #3278 bootstraps vcpkg upon UniGetUI opening (giving it the new version with the updated code), it doesn't `git pull` (as recommended by the above issue, avoiding the configuration being out-of-sync) unless this setting is enabled, causing idiosyncrasies and subtle issues. Things like this was why I hadn't done what 9e3482c307cb549692cf3938af7adf9f70c341db did originally, as I've encountered many bugs in the past with different vcpkg versions not working with my current environment. While this is an issue I encountered due to a too-recent vcpkg version, most (if not all) I've encountered were because a new vcpkg version attempted to interact with an old vcpkg directory. This PR should hopefully fix some confusion and prevent some errors, keeping the vcpkg version and directory in sync.

![Image](https://github.com/user-attachments/assets/7f95c4fb-1074-4ee3-9008-649f7fc052f2)