### PR TITLE
Use PreviewKeyDown instead of KeyUp to handle package list keyboard shortcuts

### DIFF
--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml
@@ -503,7 +503,6 @@
                 Package="{x:Bind Package}" Wrapper="{x:Bind Self}"
                 RightTapped="PackageItemContainer_RightTapped"
                 DoubleTapped="PackageItemContainer_DoubleTapped"
-                KeyUp="PackageItemContainer_KeyUp"
                 PreviewKeyDown="PackageItemContainer_PreviewKeyDown">
 
                 <Grid ColumnSpacing="5" Opacity="{x:Bind ListedOpacity, Mode=OneWay}" Padding="12,3,8,3">

--- a/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/AbstractPackagesPage.xaml.cs
@@ -950,44 +950,6 @@ namespace UniGetUI.Interface
             }
         }
 
-        private void PackageItemContainer_KeyUp(object sender, KeyRoutedEventArgs e)
-        {
-            IPackage? package = (sender as PackageItemContainer)?.Package;
-
-            bool IS_CONTROL_PRESSED = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-            //bool IS_SHIFT_PRESSED = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
-            bool IS_ALT_PRESSED = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.LeftMenu).HasFlag(CoreVirtualKeyStates.Down);
-            IS_ALT_PRESSED |= InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.RightMenu).HasFlag(CoreVirtualKeyStates.Down);
-
-            if (e.Key == VirtualKey.Enter && package is not null)
-            {
-                if (IS_ALT_PRESSED)
-                {
-                    if (!package.Source.IsVirtualManager && package is not InvalidImportedPackage)
-                        ShowInstallationOptionsForPackage(package);
-                }
-                else if (IS_CONTROL_PRESSED)
-                {
-                    if (package is not InvalidImportedPackage)
-                        PerformMainPackageAction(package);
-                }
-                else
-                {
-                    if (!package.Source.IsVirtualManager && package is not InvalidImportedPackage)
-                    {
-                        TEL_InstallReferral referral = TEL_InstallReferral.ALREADY_INSTALLED;
-                        if (PAGE_NAME == "Bundles") referral = TEL_InstallReferral.FROM_BUNDLE;
-                        if (PAGE_NAME == "Discover") referral = TEL_InstallReferral.DIRECT_SEARCH;
-                        ShowDetailsForPackage(package, referral);
-                    }
-                }
-            }
-            else if (e.Key == VirtualKey.Space && package is not null)
-            {
-                package.IsChecked = !package.IsChecked;
-            }
-        }
-
         private void SelectAllCheckBox_ValueChanged(object sender, RoutedEventArgs e)
         {
             if (SelectAllCheckBox.IsChecked == true)
@@ -1118,7 +1080,7 @@ namespace UniGetUI.Interface
 
         private void PackageItemContainer_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
         {
-            if (e.Key is not (VirtualKey.Up or VirtualKey.Down or VirtualKey.Home or VirtualKey.End) ||
+            if (e.Key is not (VirtualKey.Up or VirtualKey.Down or VirtualKey.Home or VirtualKey.End or VirtualKey.Enter or VirtualKey.Space) ||
                 sender is not PackageItemContainer packageItemContainer)
             {
                 return;
@@ -1128,15 +1090,63 @@ namespace UniGetUI.Interface
             switch (e.Key)
             {
                 case VirtualKey.Up when index > 0:
-                    SelectAndScrollTo(index - 1, true); break;
+                    SelectAndScrollTo(index - 1, true); e.Handled = true; break;
                 case VirtualKey.Down when index < FilteredPackages.Count - 1:
-                    SelectAndScrollTo(index + 1, true); break;
+                    SelectAndScrollTo(index + 1, true); e.Handled = true; break;
                 case VirtualKey.Home when index > 0:
-                    SelectAndScrollTo(0, true); break;
+                    SelectAndScrollTo(0, true); e.Handled = true; break;
                 case VirtualKey.End when index < FilteredPackages.Count - 1:
-                    SelectAndScrollTo(FilteredPackages.Count - 1, true); break;
+                    SelectAndScrollTo(FilteredPackages.Count - 1, true); e.Handled = true; break;
             }
-            e.Handled = true;
+
+            if (e.KeyStatus.WasKeyDown)
+            {
+                // ignore repeated KeyDown events when pressing and holding a key
+                return;
+            }
+
+            IPackage? package = packageItemContainer.Package;
+
+            bool IS_CONTROL_PRESSED = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            //bool IS_SHIFT_PRESSED = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+            bool IS_ALT_PRESSED = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.LeftMenu).HasFlag(CoreVirtualKeyStates.Down);
+            IS_ALT_PRESSED |= InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.RightMenu).HasFlag(CoreVirtualKeyStates.Down);
+
+            if (e.Key == VirtualKey.Enter && package is not null)
+            {
+                if (IS_ALT_PRESSED)
+                {
+                    if (!package.Source.IsVirtualManager && package is not InvalidImportedPackage)
+                    {
+                        ShowInstallationOptionsForPackage(package);
+                        e.Handled = true;
+                    }
+                }
+                else if (IS_CONTROL_PRESSED)
+                {
+                    if (package is not InvalidImportedPackage)
+                    {
+                        PerformMainPackageAction(package);
+                        e.Handled = true;
+                    }
+                }
+                else
+                {
+                    if (!package.Source.IsVirtualManager && package is not InvalidImportedPackage)
+                    {
+                        TEL_InstallReferral referral = TEL_InstallReferral.ALREADY_INSTALLED;
+                        if (PAGE_NAME == "Bundles") referral = TEL_InstallReferral.FROM_BUNDLE;
+                        if (PAGE_NAME == "Discover") referral = TEL_InstallReferral.DIRECT_SEARCH;
+                        ShowDetailsForPackage(package, referral);
+                        e.Handled = true;
+                    }
+                }
+            }
+            else if (e.Key == VirtualKey.Space && package is not null)
+            {
+                package.IsChecked = !package.IsChecked;
+                e.Handled = true;
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

I noticed that #3354 does not fully fix #3298 as the package list still uses KeyUp to handle keyboard shortcuts. Moved the key press handling to PreviewKeyDown to fix this.

-----

Relates to #3298
