### PR TITLE
Make 'Pause updates for' submenu item use translation

### DIFF
--- a/src/UniGetUI/Pages/SoftwarePages/SoftwareUpdatesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/SoftwareUpdatesPage.cs
@@ -153,7 +153,7 @@ namespace UniGetUI.Interface.SoftwarePages
 
             MenuFlyoutSubItem menuPause = new()
             {
-                Text = "Pause updates for",
+                Text = CoreTools.AutoTranslated("Pause updates for"),
                 Icon = new FontIcon { Glyph = "\uE769" },
             };
             foreach (IgnoredUpdatesDatabase.PauseTime menuTime in new List<IgnoredUpdatesDatabase.PauseTime>{


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [X] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [X] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [X] **Have you tested that the committed code can be executed without errors?**
- [X] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----
This submenu item was not translated and was missing the call to 'CoreTools.AutoTranslated'.
After rebuilding the item was still not translated - not sure about this, but it seems that you need to use the tools from the scripts directory to update the translations, which I couldn't do, because they required an API key and the one I generated myself on tolgee didn't work (403).
