### PR TITLE
Update Scoop nirsoft bucket URL to ScoopInstaller/Nirsoft

### DIFF
--- a/src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs
+++ b/src/UniGetUI.PackageEngine.Managers.Scoop/Scoop.cs
@@ -78,7 +78,7 @@ namespace UniGetUI.PackageEngine.Managers.ScoopManager
                 KnownSources = [new ManagerSource(this, "main", new Uri("https://github.com/ScoopInstaller/Main")),
                                 new ManagerSource(this, "extras", new Uri("https://github.com/ScoopInstaller/Extras")),
                                 new ManagerSource(this, "versions", new Uri("https://github.com/ScoopInstaller/Versions")),
-                                new ManagerSource(this, "nirsoft", new Uri("https://github.com/kodybrown/scoop-nirsoft")),
+                                new ManagerSource(this, "nirsoft", new Uri("https://github.com/ScoopInstaller/Nirsoft")),
                                 new ManagerSource(this, "sysinternals", new Uri("https://github.com/niheaven/scoop-sysinternals")),
                                 new ManagerSource(this, "php", new Uri("https://github.com/ScoopInstaller/PHP")),
                                 new ManagerSource(this, "nerd-fonts", new Uri("https://github.com/matthewjberger/scoop-nerd-fonts")),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

Changes:
 - Updated the URL for the official Scoop nirsoft to ScoopInstaller/Nirsoft to reflect the change made to the official buckets in Scoop commit [ad0f6178d05192497c07aef55d4f3aff7516b982](https://github.com/ScoopInstaller/Scoop/commit/ad0f6178d05192497c07aef55d4f3aff7516b982)