### PR TITLE
Warn the user when a bundle contains potentially harmful prefs

### DIFF
--- a/src/UniGetUI.Interface.Enums/Enums.cs
+++ b/src/UniGetUI.Interface.Enums/Enums.cs
@@ -93,4 +93,16 @@ namespace UniGetUI.Interface.Enums
         public const string UpdateAllPackages = "updateAll";
         public const string ReleaseSelfUpdateLock = "releaseSelfUpdateLock";
     }
+
+    public struct BundleReportEntry
+    {
+        public readonly string Line;
+        public readonly bool Allowed;
+
+        public BundleReportEntry(string line, bool allowed)
+        {
+            Line = line;
+            Allowed = allowed;
+        }
+    }
 }

--- a/src/UniGetUI/Pages/DialogPages/DialogHelper_Packages.cs
+++ b/src/UniGetUI/Pages/DialogPages/DialogHelper_Packages.cs
@@ -1,3 +1,4 @@
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
@@ -5,6 +6,7 @@ using Microsoft.UI.Xaml.Media;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.Tools;
 using UniGetUI.Interface.Dialogs;
+using UniGetUI.Interface.Enums;
 using UniGetUI.Interface.Telemetry;
 using UniGetUI.PackageEngine;
 using UniGetUI.PackageEngine.Enums;
@@ -199,28 +201,49 @@ public static partial class DialogHelper
         }
     }
 
-    public static async Task ShowBundleSecurityReport(Dictionary<string, List<string>> packageReport)
+    public static async Task ShowBundleSecurityReport(Dictionary<string, List<BundleReportEntry>> packageReport)
     {
         var dialog = DialogFactory.Create_AsWindow(true, true);
+        Brush bad = new SolidColorBrush(Colors.PaleVioletRed);
+        Brush good = new SolidColorBrush(Colors.Gold);
+
+        if (Window.NavigationPage.ActualTheme is ElementTheme.Light)
+        {
+            bad = new SolidColorBrush(Colors.Red);
+            good = new SolidColorBrush(Colors.DarkGoldenrod);
+        }
 
         var title = CoreTools.Translate("Bundle security report");
         dialog.Title = title;
         Hyperlink a;
-
-        string reportBody = "";
+        Paragraph p = new();
 
         foreach(var pair in packageReport)
         {
-            reportBody += $" - {CoreTools.Translate("Package")}: {pair.Key}:\n";
+            p.Inlines.Add(new Run()
+            {
+                Text = $" - {CoreTools.Translate("Package")}: {pair.Key}:\n",
+                FontFamily = new("Consolas")
+            });
+
             foreach (var issue in pair.Value)
             {
-                reportBody += "   * " + issue + "\n";
+                p.Inlines.Add(new Run()
+                {
+                    Text = $"   * {issue.Line}\n",
+                    FontFamily = new("Consolas"),
+                    Foreground = issue.Allowed? bad: good
+                });
             }
-            reportBody += "\n";
+            p.Inlines.Add(new LineBreak());
         }
 
         dialog.Content = new ScrollViewer()
         {
+            MaxWidth = 800,
+            Background = (Brush)Application.Current.Resources["ApplicationPageBackgroundThemeBrush"],
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(16),
             Content = new RichTextBlock()
             {
                 Blocks = {
@@ -229,25 +252,39 @@ public static partial class DialogHelper
                         Inlines = {
                             new Run()
                             {
-                                Text = CoreTools.Translate("The bundle had some settings that are currently restricted for security reasons, so they have been ignored.") +
-                                    CoreTools.Translate("You can change this behaviour on UniGetUI security settings. ")
+                                Text = CoreTools.Translate("This package bundle had some settings that are potetially dangerous, and may be ignored by default.")
+                            },
+                            new Run()
+                            {
+                                Text = "\n - " + CoreTools.Translate("Entries that show in YELLOW will be IGNORED."),
+                                Foreground = good,
+                            },
+                            new Run()
+                            {
+                                Text = "\n - " + CoreTools.Translate("Entries that show in RED will be IMPORTED."),
+                                Foreground = bad
+                            },
+                            new Run()
+                            {
+                                Text = "\n" + CoreTools.Translate("You can change this behaviour on UniGetUI security settings.") + " "
                             },
                             (a = new Hyperlink
                             {
                                 Inlines = { new Run() { Text = CoreTools.Translate("Open UniGetUI security settings") } },
                             }),
                             new LineBreak(),
-                            new LineBreak(),
-                            new Run() { Text = CoreTools.Translate("Details of the report:") },
-                            new LineBreak(),
-                            new LineBreak(),
                             new Run()
                             {
-                                Text = reportBody,
-                                FontFamily = new FontFamily("Consolas")
-                            }
+                                Text = CoreTools.Translate("Should you modify the security settings, you will need to open the bundle again for the changes to take effect.")
+                            },
+                            new LineBreak(),
+                            new LineBreak(),
+                            new Run() { Text = CoreTools.Translate("Details of the report:") },
+                            new Run() { Text = CoreTools.Translate("Details of the report:") },
+                            new LineBreak(),
                         }
-                    }
+                    },
+                    p
                 }
             }
         };

--- a/src/UniGetUI/Pages/DialogPages/DialogHelper_Packages.cs
+++ b/src/UniGetUI/Pages/DialogPages/DialogHelper_Packages.cs
@@ -280,7 +280,6 @@ public static partial class DialogHelper
                             new LineBreak(),
                             new LineBreak(),
                             new Run() { Text = CoreTools.Translate("Details of the report:") },
-                            new Run() { Text = CoreTools.Translate("Details of the report:") },
                             new LineBreak(),
                         }
                     },

--- a/src/UniGetUI/Pages/DialogPages/DialogHelper_Packages.cs
+++ b/src/UniGetUI/Pages/DialogPages/DialogHelper_Packages.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
 using UniGetUI.Core.Logging;
 using UniGetUI.Core.Tools;
@@ -10,6 +11,7 @@ using UniGetUI.PackageEngine.Enums;
 using UniGetUI.PackageEngine.Interfaces;
 using UniGetUI.PackageEngine.PackageClasses;
 using UniGetUI.PackageEngine.Serializable;
+using UniGetUI.Pages.SettingsPages.GeneralPages;
 
 namespace UniGetUI.Pages.DialogPages;
 
@@ -195,5 +197,65 @@ public static partial class DialogHelper
             await Window.ShowDialogAsync(warningDialog);
 
         }
+    }
+
+    public static async Task ShowBundleSecurityReport(Dictionary<string, List<string>> packageReport)
+    {
+        var dialog = DialogFactory.Create_AsWindow(true, true);
+
+        var title = CoreTools.Translate("Bundle security report");
+        dialog.Title = title;
+        Hyperlink a;
+
+        string reportBody = "";
+
+        foreach(var pair in packageReport)
+        {
+            reportBody += $" - {CoreTools.Translate("Package")}: {pair.Key}:\n";
+            foreach (var issue in pair.Value)
+            {
+                reportBody += "   * " + issue + "\n";
+            }
+            reportBody += "\n";
+        }
+
+        dialog.Content = new ScrollViewer()
+        {
+            Content = new RichTextBlock()
+            {
+                Blocks = {
+                    new Paragraph()
+                    {
+                        Inlines = {
+                            new Run()
+                            {
+                                Text = CoreTools.Translate("The bundle had some settings that are currently restricted for security reasons, so they have been ignored.") +
+                                    CoreTools.Translate("You can change this behaviour on UniGetUI security settings. ")
+                            },
+                            (a = new Hyperlink
+                            {
+                                Inlines = { new Run() { Text = CoreTools.Translate("Open UniGetUI security settings") } },
+                            }),
+                            new LineBreak(),
+                            new LineBreak(),
+                            new Run() { Text = CoreTools.Translate("Details of the report:") },
+                            new LineBreak(),
+                            new LineBreak(),
+                            new Run()
+                            {
+                                Text = reportBody,
+                                FontFamily = new FontFamily("Consolas")
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        a.Click += (_, _) => {
+            dialog.Hide();
+            Window.NavigationPage.OpenSettingsPage(typeof(Administrator));
+        };
+        dialog.SecondaryButtonText = CoreTools.Translate("Close");
+        await Window.ShowDialogAsync(dialog);
     }
 }

--- a/src/UniGetUI/Pages/SettingsPages/GeneralPages/Administrator.xaml
+++ b/src/UniGetUI/Pages/SettingsPages/GeneralPages/Administrator.xaml
@@ -75,33 +75,29 @@
                 SettingName="AllowPrePostInstallCommands"
                 Text="Ignore custom pre-install and post-install commands when importing packages from a bundle"
                 WarningText="Pre and post install commands will be run before and after a package gets installed, upgraded or uninstalled. Be aware thay they may break things unless used carefully" /
-            >
+            -->
 
             <widgets:TranslatedTextBlock
                 Margin="4,32,4,8"
                 FontWeight="SemiBold"
                 Text="Restrictions when importing package bundles" />
 
-            <
-                widgets:SecureCheckboxCard
+            <widgets:SecureCheckboxCard
                 x:Name="AllowImportingCLIArguments"
                 CornerRadius="8,8,0,0"
-                ForceInversion="true"
                 IsEnabled="{x:Bind AllowCLIArguments._checkbox.IsOn, Mode=OneWay}"
                 SettingName="AllowImportingCLIArguments"
-                Text="Ignore custom command-line arguments when importing packages from a bundle"
-                WarningText="Malformed command-line arguments can break packages, or even gain remote execution. Therefore, importing custom command-line arguments is disabled by default" /
-            >
+                Text="Allow importing custom command-line arguments when importing packages from a bundle"
+                WarningText="Malformed command-line arguments can break packages, or even gain remote execution. Therefore, importing custom command-line arguments is disabled by default" />
 
-            <
+            <!--
                 widgets:SecureCheckboxCard
                 x:Name="AllowImportingPrePostInstallCommands"
                 BorderThickness="1,0,1,1"
                 CornerRadius="0,0,8,8"
-                ForceInversion="true"
                 IsEnabled="{x:Bind AllowPrePostInstallCommands._checkbox.IsOn, Mode=OneWay}"
                 SettingName="AllowImportingPrePostInstallCommands"
-                Text="Ignore custom pre-install and post-install commands when importing packages from a bundle"
+                Text="Allow importing custom pre-install and post-install commands when importing packages from a bundle"
                 WarningText="Pre and post install commands can do very nasty things to your device, if designed to do so. It can be very dangerous to import the commands from a bundle, unless you trust the source of that package bundle" /
             -->
         </StackPanel>

--- a/src/UniGetUI/Pages/SoftwarePages/PackageBundlesPage.cs
+++ b/src/UniGetUI/Pages/SoftwarePages/PackageBundlesPage.cs
@@ -660,19 +660,51 @@ namespace UniGetUI.Interface.SoftwarePages
 
 
             bool showReport = false;
-            var packageReport = new Dictionary<string, List<string>>();
-            bool AllowCLIParameters = SecureSettings.Get(SecureSettings.ALLOW_IMPORTING_CLI_ARGUMENTS);
+            var packageReport = new Dictionary<string, List<BundleReportEntry>>();
+            bool AllowCLIParameters =
+                SecureSettings.Get(SecureSettings.ALLOW_CLI_ARGUMENTS) &&
+                SecureSettings.Get(SecureSettings.ALLOW_IMPORTING_CLI_ARGUMENTS);
+
 
             foreach (var pkg in DeserializedData.packages)
             {
-                if(!AllowCLIParameters && pkg.InstallationOptions.CustomParameters.Where(x => x.Any()).Any())
+                if (pkg.InstallationOptions.CustomParameters_Install.Where(x => x.Any()).Any())
                 {
                     showReport = true;
-                    if (!packageReport.ContainsKey(pkg.Id)) packageReport[pkg.Id] = new();
-                    packageReport[pkg.Id].Add($"Custom arguments: [{string.Join(", ", pkg.InstallationOptions.CustomParameters)}]");
-                    pkg.InstallationOptions.CustomParameters.Clear();
+                    if (!packageReport.ContainsKey(pkg.Id))
+                        packageReport[pkg.Id] = new();
+
+                    packageReport[pkg.Id].Add(new(
+                        $"Custom install arguments: [{string.Join(", ", pkg.InstallationOptions.CustomParameters_Install)}]",
+                        AllowCLIParameters));
+
+                    if(!AllowCLIParameters) pkg.InstallationOptions.CustomParameters_Install.Clear();
                 }
-                
+                if (pkg.InstallationOptions.CustomParameters_Update.Where(x => x.Any()).Any())
+                {
+                    showReport = true;
+                    if (!packageReport.ContainsKey(pkg.Id))
+                        packageReport[pkg.Id] = new();
+
+                    packageReport[pkg.Id].Add(new(
+                        $"Custom update arguments: [{string.Join(", ", pkg.InstallationOptions.CustomParameters_Update)}]",
+                        AllowCLIParameters));
+
+                    if(!AllowCLIParameters) pkg.InstallationOptions.CustomParameters_Update.Clear();
+                }
+                if (pkg.InstallationOptions.CustomParameters_Uninstall.Where(x => x.Any()).Any())
+                {
+                    showReport = true;
+                    if (!packageReport.ContainsKey(pkg.Id))
+                        packageReport[pkg.Id] = new();
+
+                    packageReport[pkg.Id].Add(new(
+                        $"Custom uninstall arguments: [{string.Join(", ", pkg.InstallationOptions.CustomParameters_Uninstall)}]",
+                        AllowCLIParameters));
+
+                    if(!AllowCLIParameters) pkg.InstallationOptions.CustomParameters_Uninstall.Clear();
+                }
+
                 packages.Add(DeserializePackage(pkg));
             }
 


### PR DESCRIPTION
Display a report and warn the user when an imported package bundle contains potentially unsafe install options.

Each affected package, and the settings that triggered the alert will be displayed