### PR TITLE
Clear older versions of PowerShell7 modules on update

### DIFF
--- a/src/UniGetUI.PackageEngine.Enums/ManagerCapabilities.cs
+++ b/src/UniGetUI.PackageEngine.Enums/ManagerCapabilities.cs
@@ -24,6 +24,7 @@ namespace UniGetUI.PackageEngine.ManagerClasses.Manager
         public bool CanRunInteractively = false;
         public bool CanRemoveDataOnUninstall = false;
         public bool CanDownloadInstaller = false;
+        public bool CanUninstallPreviousVersionsAfterUpdate = false;
         public bool SupportsCustomVersions = false;
         public bool SupportsCustomArchitectures = false;
         public string[] SupportedCustomArchitectures = [];

--- a/src/UniGetUI.PackageEngine.Managers.PowerShell7/PowerShell7.cs
+++ b/src/UniGetUI.PackageEngine.Managers.PowerShell7/PowerShell7.cs
@@ -27,6 +27,7 @@ namespace UniGetUI.PackageEngine.Managers.PowerShell7Manager
                 SupportsPreRelease = true,
                 CanDownloadInstaller = true,
                 SupportsCustomPackageIcons = true,
+                CanUninstallPreviousVersionsAfterUpdate = true,
                 Sources = new SourceCapabilities
                 {
                     KnowsPackageCount = false,

--- a/src/UniGetUI.PackageEngine.Serializable/InstallOptions.cs
+++ b/src/UniGetUI.PackageEngine.Serializable/InstallOptions.cs
@@ -19,6 +19,7 @@ namespace UniGetUI.PackageEngine.Serializable
         public bool SkipMinorUpdates { get; set; }
         public bool OverridesNextLevelOpts { get; set; }
         public bool RemoveDataOnUninstall { get; set; }
+        public bool UninstallPreviousVersionsOnUpdate { get; set; }
         public List<string> KillBeforeOperation { get; set; } = [];
 
         public string PreInstallCommand { get; set; } = "";
@@ -59,7 +60,8 @@ namespace UniGetUI.PackageEngine.Serializable
                 PostUninstallCommand = PostUninstallCommand,
                 AbortOnPreInstallFail = AbortOnPreInstallFail,
                 AbortOnPreUpdateFail = AbortOnPreUpdateFail,
-                AbortOnPreUninstallFail = AbortOnPreUninstallFail
+                AbortOnPreUninstallFail = AbortOnPreUninstallFail,
+                UninstallPreviousVersionsOnUpdate = UninstallPreviousVersionsOnUpdate,
             };
         }
 
@@ -92,6 +94,7 @@ namespace UniGetUI.PackageEngine.Serializable
             this.CustomInstallLocation = data[nameof(CustomInstallLocation)]?.GetVal<string>() ?? "";
             this.Version = data[nameof(Version)]?.GetVal<string>() ?? "";
             this.SkipMinorUpdates = data[nameof(SkipMinorUpdates)]?.GetVal<bool>() ?? false;
+            this.UninstallPreviousVersionsOnUpdate = data[nameof(UninstallPreviousVersionsOnUpdate)]?.GetVal<bool>() ?? false;
 
             this.PreInstallCommand = data[nameof(PreInstallCommand)]?.GetVal<string>() ?? "";
             this.PreUpdateCommand = data[nameof(PreUpdateCommand)]?.GetVal<string>() ?? "";
@@ -143,6 +146,7 @@ namespace UniGetUI.PackageEngine.Serializable
                    AbortOnPreUpdateFail is not true ||
                    PreUninstallCommand.Any() ||
                    PostUninstallCommand.Any() ||
+                   UninstallPreviousVersionsOnUpdate is not false ||
                    AbortOnPreUninstallFail is not true;
             // OverridesNextLevelOpts does not need to be checked here, since
             // this method is invoked before this property has been set
@@ -179,6 +183,7 @@ namespace UniGetUI.PackageEngine.Serializable
                    $"AbortOnPreUpdateFail={AbortOnPreUpdateFail};" +
                    $"PreUninstallCommand={PreUninstallCommand};" +
                    $"PostUninstallCommand={PostUninstallCommand};" +
+                   $"UninstallPreviousVersionsOnUpdate={UninstallPreviousVersionsOnUpdate}" +
                    $"AbortOnPreUninstallFail={AbortOnPreUninstallFail};" +
                    $"PreRelease={PreRelease}>";
         }

--- a/src/UniGetUI/Pages/DialogPages/InstallOptions_Manager.xaml
+++ b/src/UniGetUI/Pages/DialogPages/InstallOptions_Manager.xaml
@@ -67,6 +67,7 @@
                 <CheckBox Name="InteractiveCheckBox" Click="InteractiveCheckBox_Click" />
                 <CheckBox Name="HashCheckBox" Click="HashCheckbox_Click" />
                 <CheckBox Name="PreReleaseCheckBox" Click="PreReleaseCheckBox_Click" />
+                <CheckBox Name="UninstallPreviousVerOnUpdate" Click="ClearPreviousOnUpdate_OnClick" />
 
             </controls:WrapPanel>
             <!--  ARCHITECTURE COMBOBOX  -->

--- a/src/UniGetUI/Pages/DialogPages/InstallOptions_Manager.xaml.cs
+++ b/src/UniGetUI/Pages/DialogPages/InstallOptions_Manager.xaml.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using UniGetUI.Core.Language;
+using UniGetUI.Core.SettingsEngine;
 using UniGetUI.Core.SettingsEngine.SecureSettings;
 using UniGetUI.Core.Tools;
 using UniGetUI.PackageEngine.Enums;
@@ -26,6 +27,7 @@ public sealed partial class InstallOptions_Manager : UserControl
         AdminCheckBox.Content = CoreTools.Translate("Run as admin");
         InteractiveCheckBox.Content = CoreTools.Translate("Interactive installation");
         HashCheckBox.Content = CoreTools.Translate("Skip hash check");
+        UninstallPreviousVerOnUpdate.Content = CoreTools.Translate("Uninstall previous versions when updated");
         PreReleaseCheckBox.Content = CoreTools.Translate("Allow pre-release versions");
         ArchLabel.Text = CoreTools.Translate("Architecture to install:");
         ScopeLabel.Text = CoreTools.Translate("Installation scope:");
@@ -149,6 +151,9 @@ public sealed partial class InstallOptions_Manager : UserControl
         CustomParameters2.Text = string.Join(' ', options.CustomParameters_Update);
         CustomParameters3.Text = string.Join(' ', options.CustomParameters_Uninstall);
 
+        UninstallPreviousVerOnUpdate.IsEnabled = Manager.Capabilities.CanUninstallPreviousVersionsAfterUpdate;
+        UninstallPreviousVerOnUpdate.IsChecked = options.UninstallPreviousVersionsOnUpdate;
+
         ResetButton.IsEnabled = true;
         ApplyButton.IsEnabled = true;
         ApplyButton.Style = (Style)Application.Current.Resources["DefaultButtonStyle"];
@@ -167,6 +172,7 @@ public sealed partial class InstallOptions_Manager : UserControl
         options.SkipHashCheck = HashCheckBox.IsChecked ?? false;
         options.InteractiveInstallation = InteractiveCheckBox.IsChecked ?? false;
         options.PreRelease = PreReleaseCheckBox.IsChecked ?? false;
+        options.UninstallPreviousVersionsOnUpdate = UninstallPreviousVerOnUpdate.IsChecked ?? false;
 
         // Administrator
         options.Architecture = "";
@@ -216,6 +222,7 @@ public sealed partial class InstallOptions_Manager : UserControl
         InteractiveCheckBox.IsEnabled = false;
         HashCheckBox.IsEnabled = false;
         ArchitectureCombo.IsEnabled = false;
+        UninstallPreviousVerOnUpdate.IsEnabled = false;
         ScopeCombo.IsEnabled = false;
         SelectDir.IsEnabled = false;
         ResetDir.IsEnabled = false;
@@ -293,5 +300,10 @@ public sealed partial class InstallOptions_Manager : UserControl
     private void GoToSecureSettings_Click(object sender, RoutedEventArgs e)
     {
         MainApp.Instance.MainWindow.NavigationPage.OpenSettingsPage(typeof(Administrator));
+    }
+
+    private void ClearPreviousOnUpdate_OnClick(object sender, RoutedEventArgs e)
+    {
+        ApplyButton.Style = (Style)Application.Current.Resources["AccentButtonStyle"];
     }
 }

--- a/src/UniGetUI/Pages/DialogPages/InstallOptions_Package.xaml
+++ b/src/UniGetUI/Pages/DialogPages/InstallOptions_Package.xaml
@@ -200,6 +200,9 @@
                                             <CheckBox Name="HashCheckbox" Click="HashCheckbox_Click">
                                                 <widgets:TranslatedTextBlock HorizontalAlignment="Stretch" Text="Skip hash check" />
                                             </CheckBox>
+                                            <CheckBox Name="UninstallPreviousOnUpdate">
+                                                <widgets:TranslatedTextBlock HorizontalAlignment="Stretch" Text="Uninstall previous versions when updated" />
+                                            </CheckBox>
                                         </controls:WrapPanel>
                                         <Grid
                                             Padding="4,8"

--- a/src/UniGetUI/Pages/DialogPages/InstallOptions_Package.xaml.cs
+++ b/src/UniGetUI/Pages/DialogPages/InstallOptions_Package.xaml.cs
@@ -97,6 +97,7 @@ namespace UniGetUI.Interface.Dialogs
             AdminCheckBox.IsChecked = Options.RunAsAdministrator;
             InteractiveCheckBox.IsChecked = Options.InteractiveInstallation;
             HashCheckbox.IsChecked = Options.SkipHashCheck;
+            UninstallPreviousOnUpdate.IsChecked = Options.UninstallPreviousVersionsOnUpdate;
 
             ArchitectureComboBox.Items.Add(CoreTools.Translate("Default"));
             ArchitectureComboBox.SelectedIndex = 0;
@@ -226,6 +227,9 @@ namespace UniGetUI.Interface.Dialogs
                     operation is not OperationType.Uninstall
                     && Package.Manager.Capabilities.CanSkipIntegrityChecks;
 
+                UninstallPreviousOnUpdate.IsEnabled = Package.Manager.Capabilities.CanUninstallPreviousVersionsAfterUpdate;
+                UninstallPreviousOnUpdate.Visibility = Package.Manager.Capabilities.CanUninstallPreviousVersionsAfterUpdate? Visibility.Visible: Visibility.Collapsed;
+
                 ArchitectureComboBox.IsEnabled =
                     operation is not OperationType.Uninstall
                     && Package.Manager.Capabilities.SupportsCustomArchitectures;
@@ -302,6 +306,7 @@ namespace UniGetUI.Interface.Dialogs
             Options.RunAsAdministrator = AdminCheckBox?.IsChecked ?? false;
             Options.InteractiveInstallation = InteractiveCheckBox?.IsChecked ?? false;
             Options.SkipHashCheck = HashCheckbox?.IsChecked ?? false;
+            Options.UninstallPreviousVersionsOnUpdate = UninstallPreviousOnUpdate?.IsChecked ?? false;
             Options.OverridesNextLevelOpts = !FollowGlobalOptionsSwitch.IsOn;
 
             Options.Architecture = "";
@@ -471,6 +476,7 @@ namespace UniGetUI.Interface.Dialogs
         {
             CommandLineViewBox.Visibility = SettingsTabBar.SelectedIndex < 3 ? Visibility.Visible : Visibility.Collapsed;
         }
+
     }
 
     public class IOP_Proc


### PR DESCRIPTION
Clear older versions of PowerShell7 modules on update. This option can be enabled per-package or on a powershell7-level basis (for all the packages)

fix #3123
fix #3342
